### PR TITLE
:memo: Add snippet to run samples script

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ npm install typed-rest-client --save
 
 ## Samples
 
-See [samples](./samples) for complete coding examples
+See [samples](./samples) for complete coding examples.
+
+```bash
+npm run samples
+```
 
 ## Contributing
 


### PR DESCRIPTION
This commit adds simple snippet for running samples from the project.
Yes, I think it will help. The `samples` project has no configuration for scripts, the content needs to be build first before it is run, so top project script should be used.

Thanks!

In the future the project `samples` project could be updated to be used directly that way:

```diff
diff --git a/samples/package.json b/samples/package.json
index 93e19a9..e2e227b 100644
--- a/samples/package.json
+++ b/samples/package.json
@@ -14,7 +14,8 @@
     "@types/q": "1.0.5"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "build": "tsc",
+    "start": "npm run build && node ./samples.js"
   },
   "author": "Microsoft Corporation",
   "license": "MIT"
```
