### PR TITLE
Support path in the base url

### DIFF
--- a/lib/RestClient.ts
+++ b/lib/RestClient.ts
@@ -33,23 +33,18 @@ export class RestClient {
      * @param {string} baseUrl - (Optional) If not specified, use full urls per request.  If supplied and a function passes a relative url, it will be appended to this
      * @param {ifm.IRequestHandler[]} handlers - handlers are typically auth handlers (basic, bearer, ntlm supplied)
      * @param {ifm.IRequestOptions} requestOptions - options for each http requests (http proxy setting, socket timeout)
-     * @param {boolean} preservePath - 
      */
     constructor(userAgent: string,
                 baseUrl?: string,
                 handlers?: ifm.IRequestHandler[],
-                requestOptions?: ifm.IRequestOptions,
-                preservePath?: boolean) {
+                requestOptions?: ifm.IRequestOptions) {
         this.client = new httpm.HttpClient(userAgent, handlers, requestOptions);
         if (baseUrl) {
             this._baseUrl = baseUrl;
         }
-
-        this._preservePath = preservePath || false;
     }
 
     private _baseUrl: string;
-    private _preservePath: boolean;
 
     /**
      * Gets a resource from an endpoint
@@ -60,7 +55,7 @@ export class RestClient {
     public async options<T>(requestUrl: string,
         options?: IRequestOptions): Promise<IRestResponse<T>> {
 
-        let url: string = util.getUrl(requestUrl, this._baseUrl, this._preservePath);
+        let url: string = util.getUrl(requestUrl, this._baseUrl);
         let res: httpm.HttpClientResponse = await this.client.options(url,
             this._headersFromOptions(options));
         return this._processResponse<T>(res, options);
@@ -75,7 +70,7 @@ export class RestClient {
     public async get<T>(requestUrl: string,
         options?: IRequestOptions): Promise<IRestResponse<T>> {
 
-        let url: string = util.getUrl(requestUrl, this._baseUrl, this._preservePath);
+        let url: string = util.getUrl(requestUrl, this._baseUrl);
         let res: httpm.HttpClientResponse = await this.client.get(url,
             this._headersFromOptions(options));
         return this._processResponse<T>(res, options);
@@ -90,7 +85,7 @@ export class RestClient {
     public async del<T>(requestUrl: string,
         options?: IRequestOptions): Promise<IRestResponse<T>> {
 
-        let url: string = util.getUrl(requestUrl, this._baseUrl, this._preservePath);
+        let url: string = util.getUrl(requestUrl, this._baseUrl);
         let res: httpm.HttpClientResponse = await this.client.del(url,
             this._headersFromOptions(options));
         return this._processResponse<T>(res, options);
@@ -107,7 +102,7 @@ export class RestClient {
         resources: any,
         options?: IRequestOptions): Promise<IRestResponse<T>> {
 
-        let url: string = util.getUrl(requestUrl, this._baseUrl, this._preservePath);
+        let url: string = util.getUrl(requestUrl, this._baseUrl);
         let headers: ifm.IHeaders = this._headersFromOptions(options, true);
 
         let data: string = JSON.stringify(resources, null, 2);
@@ -126,7 +121,7 @@ export class RestClient {
         resources: any,
         options?: IRequestOptions): Promise<IRestResponse<T>> {
 
-        let url: string = util.getUrl(requestUrl, this._baseUrl, this._preservePath);
+        let url: string = util.getUrl(requestUrl, this._baseUrl);
         let headers: ifm.IHeaders = this._headersFromOptions(options, true);
 
         let data: string = JSON.stringify(resources, null, 2);
@@ -145,7 +140,7 @@ export class RestClient {
         resources: any,
         options?: IRequestOptions): Promise<IRestResponse<T>> {
 
-        let url: string = util.getUrl(requestUrl, this._baseUrl, this._preservePath);
+        let url: string = util.getUrl(requestUrl, this._baseUrl);
         let headers: ifm.IHeaders = this._headersFromOptions(options, true);
 
         let data: string = JSON.stringify(resources, null, 2);
@@ -158,7 +153,7 @@ export class RestClient {
         stream: NodeJS.ReadableStream,
         options?: IRequestOptions): Promise<IRestResponse<T>> {
 
-        let url: string = util.getUrl(requestUrl, this._baseUrl, this._preservePath);
+        let url: string = util.getUrl(requestUrl, this._baseUrl);
         let headers: ifm.IHeaders = this._headersFromOptions(options, true);
 
         let res: httpm.HttpClientResponse = await this.client.sendStream(verb, url, stream, headers);

--- a/lib/RestClient.ts
+++ b/lib/RestClient.ts
@@ -33,18 +33,23 @@ export class RestClient {
      * @param {string} baseUrl - (Optional) If not specified, use full urls per request.  If supplied and a function passes a relative url, it will be appended to this
      * @param {ifm.IRequestHandler[]} handlers - handlers are typically auth handlers (basic, bearer, ntlm supplied)
      * @param {ifm.IRequestOptions} requestOptions - options for each http requests (http proxy setting, socket timeout)
+     * @param {boolean} preservePath - 
      */
     constructor(userAgent: string,
                 baseUrl?: string,
                 handlers?: ifm.IRequestHandler[],
-                requestOptions?: ifm.IRequestOptions) {
+                requestOptions?: ifm.IRequestOptions,
+                preservePath?: boolean) {
         this.client = new httpm.HttpClient(userAgent, handlers, requestOptions);
         if (baseUrl) {
             this._baseUrl = baseUrl;
         }
+
+        this._preservePath = preservePath || false;
     }
 
     private _baseUrl: string;
+    private _preservePath: boolean;
 
     /**
      * Gets a resource from an endpoint
@@ -55,7 +60,7 @@ export class RestClient {
     public async options<T>(requestUrl: string,
         options?: IRequestOptions): Promise<IRestResponse<T>> {
 
-        let url: string = util.getUrl(requestUrl, this._baseUrl);
+        let url: string = util.getUrl(requestUrl, this._baseUrl, this._preservePath);
         let res: httpm.HttpClientResponse = await this.client.options(url,
             this._headersFromOptions(options));
         return this._processResponse<T>(res, options);
@@ -70,7 +75,7 @@ export class RestClient {
     public async get<T>(requestUrl: string,
         options?: IRequestOptions): Promise<IRestResponse<T>> {
 
-        let url: string = util.getUrl(requestUrl, this._baseUrl);
+        let url: string = util.getUrl(requestUrl, this._baseUrl, this._preservePath);
         let res: httpm.HttpClientResponse = await this.client.get(url,
             this._headersFromOptions(options));
         return this._processResponse<T>(res, options);
@@ -85,7 +90,7 @@ export class RestClient {
     public async del<T>(requestUrl: string,
         options?: IRequestOptions): Promise<IRestResponse<T>> {
 
-        let url: string = util.getUrl(requestUrl, this._baseUrl);
+        let url: string = util.getUrl(requestUrl, this._baseUrl, this._preservePath);
         let res: httpm.HttpClientResponse = await this.client.del(url,
             this._headersFromOptions(options));
         return this._processResponse<T>(res, options);
@@ -102,7 +107,7 @@ export class RestClient {
         resources: any,
         options?: IRequestOptions): Promise<IRestResponse<T>> {
 
-        let url: string = util.getUrl(requestUrl, this._baseUrl);
+        let url: string = util.getUrl(requestUrl, this._baseUrl, this._preservePath);
         let headers: ifm.IHeaders = this._headersFromOptions(options, true);
 
         let data: string = JSON.stringify(resources, null, 2);
@@ -121,7 +126,7 @@ export class RestClient {
         resources: any,
         options?: IRequestOptions): Promise<IRestResponse<T>> {
 
-        let url: string = util.getUrl(requestUrl, this._baseUrl);
+        let url: string = util.getUrl(requestUrl, this._baseUrl, this._preservePath);
         let headers: ifm.IHeaders = this._headersFromOptions(options, true);
 
         let data: string = JSON.stringify(resources, null, 2);
@@ -140,7 +145,7 @@ export class RestClient {
         resources: any,
         options?: IRequestOptions): Promise<IRestResponse<T>> {
 
-        let url: string = util.getUrl(requestUrl, this._baseUrl);
+        let url: string = util.getUrl(requestUrl, this._baseUrl, this._preservePath);
         let headers: ifm.IHeaders = this._headersFromOptions(options, true);
 
         let data: string = JSON.stringify(resources, null, 2);
@@ -153,7 +158,7 @@ export class RestClient {
         stream: NodeJS.ReadableStream,
         options?: IRequestOptions): Promise<IRestResponse<T>> {
 
-        let url: string = util.getUrl(requestUrl, this._baseUrl);
+        let url: string = util.getUrl(requestUrl, this._baseUrl, this._preservePath);
         let headers: ifm.IHeaders = this._headersFromOptions(options, true);
 
         let res: httpm.HttpClientResponse = await this.client.sendStream(verb, url, stream, headers);

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -5,10 +5,9 @@ import * as path from 'path';
  * creates an url from a request url and optional base url (http://server:8080)
  * @param {string} requestUrl - a fully qualified url or relative url
  * @param {string} baseUrl - an optional baseUrl (http://server:8080)
- * @param {boolean} preservePath - an optional baseUrl (http://server:8080)
  * @return {string} - resultant url 
  */
-export function getUrl(requestUrl: string, baseUrl?: string, preservePath?: boolean): string  {
+export function getUrl(requestUrl: string, baseUrl?: string): string  {
     if (!baseUrl) {
         return requestUrl;
     }
@@ -21,9 +20,7 @@ export function getUrl(requestUrl: string, baseUrl?: string, preservePath?: bool
     combined.auth = combined.auth || base.auth;
     combined.host = combined.host || base.host;
 
-    if (preservePath) {
-        combined.pathname = path.join(base.pathname, combined.pathname);
-    }
+    combined.pathname = path.join(base.pathname, combined.pathname);
 
     // path from requestUrl always wins
     let res: string = url.format(combined);

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -28,7 +28,5 @@ export function getUrl(requestUrl: string, baseUrl?: string, preservePath?: bool
     // path from requestUrl always wins
     let res: string = url.format(combined);
 
-    console.log(res)
-
     return res;
 }

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -1,4 +1,5 @@
 import * as url from 'url';
+import * as path from 'path';
 
 /**
  * creates an url from a request url and optional base url (http://server:8080)
@@ -21,11 +22,13 @@ export function getUrl(requestUrl: string, baseUrl?: string, preservePath?: bool
     combined.host = combined.host || base.host;
 
     if (preservePath) {
-        combined.pathname = base.pathname + combined.pathname;
+        combined.pathname = path.join(base.pathname, combined.pathname);
     }
 
     // path from requestUrl always wins
     let res: string = url.format(combined);
+
+    console.log(res)
 
     return res;
 }

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -20,8 +20,8 @@ export function getUrl(resource: string, baseUrl?: string): string  {
     resultantUrl.auth = resultantUrl.auth || base.auth;
     resultantUrl.host = resultantUrl.host || base.host;
 
-    let basePathComponent: string = base.pathname === '/' ? '': base.pathname;
-    resultantUrl.pathname = path.posix.join(basePathComponent, resultantUrl.pathname);
+    let basePathComponent: string = base.pathname === '/' ? '' : base.pathname;
+    resultantUrl.pathname = path.posix.resolve(basePathComponent, resultantUrl.pathname);
 
     let res: string = url.format(resultantUrl);
 

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -20,9 +20,10 @@ export function getUrl(resource: string, baseUrl?: string): string  {
     resultantUrl.auth = resultantUrl.auth || base.auth;
     resultantUrl.host = resultantUrl.host || base.host;
 
-    let basePathComponent: string = base.pathname === '/'? '': base.pathname;
-    resultantUrl.pathname = path.resolve(basePathComponent, resultantUrl.pathname);
+    let basePathComponent: string = base.pathname === '/' ? '': base.pathname;
+    resultantUrl.pathname = path.posix.join(basePathComponent, resultantUrl.pathname);
 
     let res: string = url.format(resultantUrl);
+
     return res;
 }

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -4,9 +4,10 @@ import * as url from 'url';
  * creates an url from a request url and optional base url (http://server:8080)
  * @param {string} requestUrl - a fully qualified url or relative url
  * @param {string} baseUrl - an optional baseUrl (http://server:8080)
+ * @param {boolean} preservePath - an optional baseUrl (http://server:8080)
  * @return {string} - resultant url 
  */
-export function getUrl(requestUrl: string, baseUrl?: string): string  {
+export function getUrl(requestUrl: string, baseUrl?: string, preservePath?: boolean): string  {
     if (!baseUrl) {
         return requestUrl;
     }
@@ -18,8 +19,13 @@ export function getUrl(requestUrl: string, baseUrl?: string): string  {
     combined.protocol = combined.protocol || base.protocol;
     combined.auth = combined.auth || base.auth;
     combined.host = combined.host || base.host;
-    // path from requestUrl always wins
 
+    if (preservePath) {
+        combined.pathname = base.pathname + combined.pathname;
+    }
+
+    // path from requestUrl always wins
     let res: string = url.format(combined);
+
     return res;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-rest-client",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-rest-client",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-rest-client",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Node Rest and Http Clients for use with TypeScript",
   "main": "./RestClient.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -8,10 +8,6 @@
     "test": "node make.js test",
     "samples": "node make.js samples"
   },
-  "engines": {
-    "node": ">=8.9.0",
-    "npm": ">=5.5.1"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Microsoft/typed-rest-client.git"

--- a/package.json
+++ b/package.json
@@ -1,12 +1,16 @@
 {
   "name": "typed-rest-client",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "description": "Node Rest and Http Clients for use with TypeScript",
   "main": "./RestClient.js",
   "scripts": {
     "build": "node make.js build",
     "test": "node make.js test",
     "samples": "node make.js samples"
+  },
+  "engines": {
+    "node": ">=8.9.0",
+    "npm": ">=5.5.1"
   },
   "repository": {
     "type": "git",

--- a/test/resttests.ts
+++ b/test/resttests.ts
@@ -90,33 +90,9 @@ describe('Rest Tests', function () {
     //--------------------------------------------------------
     // Path in baseUrl tests
     //--------------------------------------------------------
-    it('removes the path from the base url', async() => {
-        // Arrange
-        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/pathtoremove');
-
-        // Act
-        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('/get');
-
-        // Assert
-        assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result.url === 'https://httpbin.org/get');
-    });
-
-    it('removes the path from the base url when excplicit', async() => {
-        // Arrange
-        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/pathtoremove', null, null, false);
-
-        // Act
-        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('/get');
-
-        // Assert
-        assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result.url === 'https://httpbin.org/get');
-    });
-
     it('maintains the path from the base url', async() => {
         // Arrange
-        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything', null, null, true);
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything');
 
         // Act
         let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('/anythingextra');
@@ -128,33 +104,31 @@ describe('Rest Tests', function () {
 
     it('maintains the path from the base url with no slashes', async() => {
         // Arrange
-        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything', null, null, true);
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything');
 
         // Act
         let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra');
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        console.log(restRes.result.url)
         assert(restRes.result.url === 'https://httpbin.org/anything/anythingextra');
     });
 
     it('maintains the path from the base url with double slashes', async() => {
         // Arrange
-        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything/', null, null, true);
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything/');
 
         // Act
         let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('/anythingextra');
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        console.log(restRes.result.url)
         assert(restRes.result.url === 'https://httpbin.org/anything/anythingextra');
     });
 
     it('maintains the path from the base url with multiple parts', async() => {
         // Arrange
-        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything/extrapart', null, null, true);
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything/extrapart');
 
         // Act
         let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('/anythingextra');
@@ -166,7 +140,7 @@ describe('Rest Tests', function () {
 
     it('maintains the path from the base url where request has multiple parts', async() => {
         // Arrange
-        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything', null, null, true);
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything');
 
         // Act
         let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('/anythingextra/moreparts');
@@ -178,7 +152,7 @@ describe('Rest Tests', function () {
 
     it('maintains the path from the base url where both have multiple parts', async() => {
         // Arrange
-        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything/multiple', null, null, true);
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything/multiple');
 
         // Act
         let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('/anythingextra/moreparts');
@@ -190,7 +164,7 @@ describe('Rest Tests', function () {
 
     it('maintains the path from the base url where request has query parameters', async() => {
         // Arrange
-        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything/multiple', null, null, true);
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything/multiple');
 
         // Act
         let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('/anythingextra/moreparts?foo=bar&baz=top');

--- a/test/resttests.ts
+++ b/test/resttests.ts
@@ -9,6 +9,7 @@ import * as path from 'path';
 export interface HttpBinData {
     url: string;
     data: any;
+    args?: any
 }
 
 describe('Rest Tests', function () {
@@ -84,7 +85,93 @@ describe('Rest Tests', function () {
             assert(err['statusCode'] == 500, "statusCode should be 500");
             assert(err.message && err.message.length > 0, "should have error message");
         }
-    });    
+    });
+
+    it('removes the path from the base url', async() => {
+        // Arrange
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/pathtoremove');
+
+        // Act
+        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('/get');
+
+        // Assert
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result.url === 'https://httpbin.org/get');
+    });
+
+    it('removes the path from the base url when excplicit', async() => {
+        // Arrange
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/pathtoremove', null, null, false);
+
+        // Act
+        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('/get');
+
+        // Assert
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result.url === 'https://httpbin.org/get');
+    });
+
+    it('maintains the path from the base url', async() => {
+        // Arrange
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything', null, null, true);
+
+        // Act
+        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('/anythingextra');
+
+        // Assert
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result.url === 'https://httpbin.org/anything/anythingextra');
+    });
+
+    it('maintains the path from the base url with multiple parts', async() => {
+        // Arrange
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything/extrapart', null, null, true);
+
+        // Act
+        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('/anythingextra');
+
+        // Assert
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result.url === 'https://httpbin.org/anything/extrapart/anythingextra');
+    });
+
+    it('maintains the path from the base url where request has multiple parts', async() => {
+        // Arrange
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything', null, null, true);
+
+        // Act
+        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('/anythingextra/moreparts');
+
+        // Assert
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result.url === 'https://httpbin.org/anything/anythingextra/moreparts');
+    });
+
+    it('maintains the path from the base url where both have multiple parts', async() => {
+        // Arrange
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything/multiple', null, null, true);
+
+        // Act
+        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('/anythingextra/moreparts');
+
+        // Assert
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result.url === 'https://httpbin.org/anything/multiple/anythingextra/moreparts');
+    });
+
+    it('maintains the path from the base url where request has query parameters', async() => {
+        // Arrange
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything/multiple', null, null, true);
+
+        // Act
+        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('/anythingextra/moreparts?foo=bar&baz=top');
+
+        // Assert
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result.url === 'https://httpbin.org/anything/multiple/anythingextra/moreparts?foo=bar&baz=top');
+        assert(restRes.result.args.foo === 'bar');
+        assert(restRes.result.args.baz === 'top');
+    });
 
     // TODO: more tests here    
 });

--- a/test/resttests.ts
+++ b/test/resttests.ts
@@ -187,22 +187,17 @@ describe('Rest Tests', function () {
 
     it('resolves a full resource and no baseUrl', async() => {
         let res: string = util.getUrl('http://httpbin.org/get?x=y&a=b');
-        assert(res === 'http://httpbin.org/get?x=y&a=b', "should be http://httpbin.org/get?x=y&a=b");
+        assert(res === 'http://httpbin.org/get?x=y&a=b', `should be http://httpbin.org/get?x=y&a=b but is ${res}`);
     });
 
     it('resolves a rooted path resource with host baseUrl', async() => {
         let res: string = util.getUrl('/get/foo', 'http://httpbin.org');
-        assert(res === 'http://httpbin.org/get/foo', "should be http://httpbin.org/get/foo");
-    });
-
-    it('resolves a rooted path resource with pathed baseUrl', async() => {
-        let res: string = util.getUrl('/get/foo', 'http://httpbin.org/bar');
-        assert(res === 'http://httpbin.org/get/foo', "should be http://httpbin.org/get/foo");
+        assert(res === 'http://httpbin.org/get/foo', `should be http://httpbin.org/get/foo but is ${res}`);
     });
 
     it('resolves a relative path resource with pathed baseUrl', async() => {
         let res: string = util.getUrl('get/foo', 'http://httpbin.org/bar');
-        assert(res === 'http://httpbin.org/bar/get/foo', "should be http://httpbin.org/bar/get/foo");
+        assert(res === 'http://httpbin.org/bar/get/foo', `should be http://httpbin.org/bar/get/foo but is ${res}`);
     });
     // TODO: more tests here    
 });

--- a/test/resttests.ts
+++ b/test/resttests.ts
@@ -87,6 +87,9 @@ describe('Rest Tests', function () {
         }
     });
 
+    //--------------------------------------------------------
+    // Path in baseUrl tests
+    //--------------------------------------------------------
     it('removes the path from the base url', async() => {
         // Arrange
         let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/pathtoremove');
@@ -120,6 +123,32 @@ describe('Rest Tests', function () {
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result.url === 'https://httpbin.org/anything/anythingextra');
+    });
+
+    it('maintains the path from the base url with no slashes', async() => {
+        // Arrange
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything', null, null, true);
+
+        // Act
+        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra');
+
+        // Assert
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        console.log(restRes.result.url)
+        assert(restRes.result.url === 'https://httpbin.org/anything/anythingextra');
+    });
+
+    it('maintains the path from the base url with double slashes', async() => {
+        // Arrange
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything/', null, null, true);
+
+        // Act
+        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('/anythingextra');
+
+        // Assert
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        console.log(restRes.result.url)
         assert(restRes.result.url === 'https://httpbin.org/anything/anythingextra');
     });
 

--- a/test/resttests.ts
+++ b/test/resttests.ts
@@ -96,7 +96,7 @@ describe('Rest Tests', function () {
         let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything');
 
         // Act
-        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('/anythingextra');
+        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra');
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
@@ -120,7 +120,7 @@ describe('Rest Tests', function () {
         let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything/');
 
         // Act
-        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('/anythingextra');
+        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra');
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
@@ -132,7 +132,7 @@ describe('Rest Tests', function () {
         let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything/extrapart');
 
         // Act
-        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('/anythingextra');
+        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra');
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
@@ -144,7 +144,7 @@ describe('Rest Tests', function () {
         let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything');
 
         // Act
-        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('/anythingextra/moreparts');
+        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra/moreparts');
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
@@ -156,7 +156,7 @@ describe('Rest Tests', function () {
         let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything/multiple');
 
         // Act
-        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('/anythingextra/moreparts');
+        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra/moreparts');
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
@@ -168,7 +168,7 @@ describe('Rest Tests', function () {
         let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything/multiple');
 
         // Act
-        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('/anythingextra/moreparts?foo=bar&baz=top');
+        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra/moreparts?foo=bar&baz=top');
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
@@ -193,6 +193,11 @@ describe('Rest Tests', function () {
     it('resolves a rooted path resource with host baseUrl', async() => {
         let res: string = util.getUrl('/get/foo', 'http://httpbin.org');
         assert(res === 'http://httpbin.org/get/foo', `should be http://httpbin.org/get/foo but is ${res}`);
+    });
+
+    it('resolves a rooted path resource with pathed baseUrl', async() => {
+        let res: string = util.getUrl('/get/foo', 'http://httpbin.org/bar');
+        assert(res === 'http://httpbin.org/get/foo', "should be http://httpbin.org/get/foo");
     });
 
     it('resolves a relative path resource with pathed baseUrl', async() => {


### PR DESCRIPTION
This PR adds the option to include an option to preserve the pathname specified in the base URL for the Rest Client. Default is false (maintains old behavior)