### PR TITLE
refactor(casing): Force consistent casing

### DIFF
--- a/lib/handlers/basiccreds.ts
+++ b/lib/handlers/basiccreds.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import ifm = require('../interfaces');
+import ifm = require('../Interfaces');
 
 export class BasicCredentialHandler implements ifm.IRequestHandler {
     username: string;

--- a/lib/handlers/bearertoken.ts
+++ b/lib/handlers/bearertoken.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import ifm = require('../interfaces');
+import ifm = require('../Interfaces');
 
 export class BearerCredentialHandler implements ifm.IRequestHandler {
     token: string;

--- a/lib/handlers/ntlm.ts
+++ b/lib/handlers/ntlm.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import ifm = require('../interfaces');
+import ifm = require('../Interfaces');
 
 import http = require("http");
 import https = require("https");

--- a/lib/handlers/personalaccesstoken.ts
+++ b/lib/handlers/personalaccesstoken.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import ifm = require('../interfaces');
+import ifm = require('../Interfaces');
 
 export class PersonalAccessTokenCredentialHandler implements ifm.IRequestHandler {
     token: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
         "moduleResolution": "node",
         "typeRoots": [ "node_modules/@types" ], 
         "declaration": true,
-        "outDir": "_build" 
+        "outDir": "_build",
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "lib/Index.ts",


### PR DESCRIPTION
Force consistent casing across code. This will allow people to use this library on linux builds, removing this compile error: 

```
src/client/HttpClient.ts(5,33): error TS2307: Cannot find module 'typed-rest-client/interfaces'.
```

Fixes #26 