### PR TITLE
Add npm run bt and npm run bts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,13 +15,25 @@ $ npm run build
 You should test with node 6.x and 8.x LTS.  We recommend using [nvm](https://github.com/creationix/nvm)
 
 ```
-npm test
+npm run test
 ```
 
 ## Run Samples
 
 ```
 npm run samples
+```
+
+## Combined
+
+Run build and test
+```
+npm run bt
+```
+
+Run build, test, and samples
+```
+npm run bts
 ```
 
 # Instructions for Logging Issues

--- a/make.js
+++ b/make.js
@@ -52,3 +52,16 @@ target.samples = function () {
     popd();
     console.log('done');
 }
+
+// run build and test
+target.bt = function() {
+    target.build();
+    target.test();
+}
+
+// run build, test, and samples
+target.bts = function() {
+    target.build();
+    target.test();
+    target.samples();
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "build": "node make.js build",
     "test": "node make.js test",
-    "samples": "node make.js samples"
+    "samples": "node make.js samples",
+    "bt": "node make.js bt",
+    "bts": "node make.js bts"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Add npm run commands for:
- build and test (bt)
- build, test, and samples (bts).

I did them as abbreviated, seems easier to me. If you prefer the long way(buildtest, buildtestsamples) let me know! Or we could have both versions for all cases and add npm run b and npm run t.

#31 