### PR TITLE
Enforce node and npm versions in make.js

### DIFF
--- a/make.js
+++ b/make.js
@@ -17,7 +17,7 @@ var buildPath = path.join(__dirname, '_build');
 var testPath = path.join(__dirname, 'test');
 
 // enforce minimum Node version
-var minimumNodeVersion = '6.12.0';
+var minimumNodeVersion = '4.8.6';
 var currentNodeVersion = process.versions.node;
 if (semver.lt(currentNodeVersion, minimumNodeVersion)) {
     fail('requires node >= ' + minimumNodeVersion + '.  installed: ' + currentNodeVersion);

--- a/make.js
+++ b/make.js
@@ -42,8 +42,6 @@ target.clean = function () {
 };
 
 target.build = function () {
-    target.clean();
-
     run(path.join(__dirname, 'node_modules/.bin/tsc') + ' --outDir ' + buildPath);
     cp('-Rf', rp('lib/opensource'), buildPath);
     cp(rp('package.json'), buildPath);
@@ -52,8 +50,6 @@ target.build = function () {
 }
 
 target.test = function() {
-    target.build();
-
     // install the just built lib into the test proj
     pushd('test')
     run('npm install ../_build');
@@ -64,8 +60,6 @@ target.test = function() {
 }
 
 target.samples = function () {
-    target.build();
-
     pushd('samples');
     run('node samples.js');
     popd();

--- a/make.js
+++ b/make.js
@@ -22,8 +22,8 @@ if (semver.lt(currentNodeVersion, minimumNodeVersion)) {
 // NOTE: We are enforcing this version of npm because we use package-lock.json
 var minimumNpmVersion = '5.5.1';
 var currentNpmVersion = ncp.execSync('npm -v', { encoding: 'utf-8' });
-console.log(minimumNpmVersion);
-console.log(currentNpmVersion);
+// console.log(minimumNpmVersion);
+// console.log(currentNpmVersion);
 if (semver.lt(currentNpmVersion, minimumNpmVersion)) {
     fail('requires npm >= ' + minimumNpmVersion + '.  installed: ' + currentNpmVersion);
 }

--- a/make.js
+++ b/make.js
@@ -8,6 +8,11 @@ var rp = function (relPath) {
     return path.join(__dirname, relPath);
 }
 
+var fail = function (message) {
+    console.error('ERROR: ' + message);
+    process.exit(1);
+}
+
 var buildPath = path.join(__dirname, '_build');
 var testPath = path.join(__dirname, 'test');
 

--- a/make.js
+++ b/make.js
@@ -22,8 +22,6 @@ if (semver.lt(currentNodeVersion, minimumNodeVersion)) {
 // NOTE: We are enforcing this version of npm because we use package-lock.json
 var minimumNpmVersion = '5.5.1';
 var currentNpmVersion = ncp.execSync('npm -v', { encoding: 'utf-8' });
-// console.log(minimumNpmVersion);
-// console.log(currentNpmVersion);
 if (semver.lt(currentNpmVersion, minimumNpmVersion)) {
     fail('requires npm >= ' + minimumNpmVersion + '.  installed: ' + currentNpmVersion);
 }

--- a/make.js
+++ b/make.js
@@ -1,6 +1,8 @@
 require('shelljs/make');
 var path = require('path');
 var fs = require('fs');
+var semver = require('semver');
+var ncp = require('child_process');
 
 var rp = function (relPath) {
     return path.join(__dirname, relPath);
@@ -8,6 +10,23 @@ var rp = function (relPath) {
 
 var buildPath = path.join(__dirname, '_build');
 var testPath = path.join(__dirname, 'test');
+
+// enforce minimum Node version
+var minimumNodeVersion = '6.12.0';
+var currentNodeVersion = process.versions.node;
+if (semver.lt(currentNodeVersion, minimumNodeVersion)) {
+    fail('requires node >= ' + minimumNodeVersion + '.  installed: ' + currentNodeVersion);
+}
+
+// enforce minimum npm version
+// NOTE: We are enforcing this version of npm because we use package-lock.json
+var minimumNpmVersion = '5.5.1';
+var currentNpmVersion = ncp.execSync('npm -v', { encoding: 'utf-8' });
+console.log(minimumNpmVersion);
+console.log(currentNpmVersion);
+if (semver.lt(currentNpmVersion, minimumNpmVersion)) {
+    fail('requires npm >= ' + minimumNpmVersion + '.  installed: ' + currentNpmVersion);
+}
 
 var run = function (cl) {
     console.log('> ' + cl);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-rest-client",
-  "version": "0.16.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -328,6 +328,12 @@
       "requires": {
         "path-parse": "1.0.5"
       }
+    },
+    "semver": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.3.tgz",
+      "integrity": "sha1-FUZrYSILw3HNjw5map94Uynqgig=",
+      "dev": true
     },
     "shelljs": {
       "version": "0.7.6",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "node make.js build",
     "test": "node make.js test",
-    "samples": "node make.js samples"
+    "samples": "node make.js samples",
+    "clean": "node make.js clean"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/shelljs": "0.7.4",
     "mocha": "^3.5.3",
     "shelljs": "0.7.6",
+    "semver": "4.3.3",
     "typescript": "2.4.2"
   },
   "dependencies": {

--- a/test/resttests.ts
+++ b/test/resttests.ts
@@ -31,6 +31,8 @@ describe('Rest Tests', function () {
     })
 
     it('gets a resource', async() => {
+        this.timeout(3000);
+
         let restRes: restm.IRestResponse<HttpBinData> = await _rest.get<HttpBinData>('https://httpbin.org/get');
         assert(restRes.statusCode == 200, "statusCode should be 200");
         assert(restRes.result.url === 'https://httpbin.org/get');
@@ -92,6 +94,8 @@ describe('Rest Tests', function () {
     // Path in baseUrl tests
     //--------------------------------------------------------
     it('maintains the path from the base url', async() => {
+        this.timeout(3000);
+
         // Arrange
         let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything');
 


### PR DESCRIPTION
- Requirement for node version
- Requirement for npm version
- Remove calls to build/clean from other methods. They need to be called on their own.
- Increase timeout for slow tests(run on my home machine)

#27 