### PR TITLE
Only enforce version on build.

### DIFF
--- a/make.js
+++ b/make.js
@@ -16,19 +16,21 @@ var fail = function (message) {
 var buildPath = path.join(__dirname, '_build');
 var testPath = path.join(__dirname, 'test');
 
-// enforce minimum Node version
-var minimumNodeVersion = '4.8.6';
-var currentNodeVersion = process.versions.node;
-if (semver.lt(currentNodeVersion, minimumNodeVersion)) {
-    fail('requires node >= ' + minimumNodeVersion + '.  installed: ' + currentNodeVersion);
-}
+var enforceMinimumVersions = function () {
+    // enforce minimum Node version
+    var minimumNodeVersion = '4.8.6';
+    var currentNodeVersion = process.versions.node;
+    if (semver.lt(currentNodeVersion, minimumNodeVersion)) {
+        fail('requires node >= ' + minimumNodeVersion + '.  installed: ' + currentNodeVersion);
+    }
 
-// enforce minimum npm version
-// NOTE: We are enforcing this version of npm because we use package-lock.json
-var minimumNpmVersion = '5.5.1';
-var currentNpmVersion = ncp.execSync('npm -v', { encoding: 'utf-8' });
-if (semver.lt(currentNpmVersion, minimumNpmVersion)) {
-    fail('requires npm >= ' + minimumNpmVersion + '.  installed: ' + currentNpmVersion);
+    // enforce minimum npm version
+    // NOTE: We are enforcing this version of npm because we use package-lock.json
+    var minimumNpmVersion = '5.5.1';
+    var currentNpmVersion = ncp.execSync('npm -v', { encoding: 'utf-8' });
+    if (semver.lt(currentNpmVersion, minimumNpmVersion)) {
+        fail('requires npm >= ' + minimumNpmVersion + '.  installed: ' + currentNpmVersion);
+    }
 }
 
 var run = function (cl) {
@@ -51,6 +53,7 @@ target.clean = function () {
 };
 
 target.build = function () {
+    enforceMinimumVersions();
     run(path.join(__dirname, 'node_modules/.bin/tsc') + ' --outDir ' + buildPath);
     cp('-Rf', rp('lib/opensource'), buildPath);
     cp(rp('package.json'), buildPath);


### PR DESCRIPTION
We only want to enforce versions on build. When running the tests the node version changes also change the npm version.

I found this while starting to set up builds on VSTS. This is the setup so far (using UI instead of YAML to get it working first ):

![image](https://user-images.githubusercontent.com/450490/33736722-abdaec02-db61-11e7-84a1-fc78b619675a.png)

After Use Node 4.8.6 runs and we start doing npm run test, we were getting this issue:

ERROR: requires npm >= 5.5.1.  installed: 2.15.11

I believe this change will resolve the issue since we are just testing and the versions won't be enforced.

I could also see an argument for adding a node only version enforced when testing.