### PR TITLE
Return 'null' on status 404

### DIFF
--- a/lib/RestClient.ts
+++ b/lib/RestClient.ts
@@ -174,9 +174,12 @@ export class RestClient {
 
     private async _processResponse<T>(res: httpm.HttpClientResponse, options: IRequestOptions): Promise<IRestResponse<T>> {
         return new Promise<IRestResponse<T>>(async (resolve, reject) => {
-            let rres: IRestResponse<T> = <IRestResponse<T>>{};
-            let statusCode: number = res.message.statusCode;
-            rres.statusCode = statusCode;
+            const statusCode: number = res.message.statusCode;
+
+            const rres: IRestResponse<T> = {
+                statusCode: statusCode,
+                result: null,
+            };
 
             // not found leads to null obj returned
             if (statusCode == httpm.HttpCodes.NotFound) {

--- a/lib/RestClient.ts
+++ b/lib/RestClient.ts
@@ -176,14 +176,14 @@ export class RestClient {
         return new Promise<IRestResponse<T>>(async (resolve, reject) => {
             const statusCode: number = res.message.statusCode;
 
-            const rres: IRestResponse<T> = {
+            const response: IRestResponse<T> = {
                 statusCode: statusCode,
                 result: null,
             };
 
             // not found leads to null obj returned
             if (statusCode == httpm.HttpCodes.NotFound) {
-                resolve(rres);
+                resolve(response);
             }
 
             let obj: any;
@@ -194,10 +194,10 @@ export class RestClient {
                 if (contents && contents.length > 0) {
                     obj = JSON.parse(contents);
                     if (options && options.responseProcessor) {
-                        rres.result = options.responseProcessor(obj);
+                        response.result = options.responseProcessor(obj);
                     }
                     else {
-                        rres.result = obj;
+                        response.result = obj;
                     }
                 }
             }
@@ -220,13 +220,13 @@ export class RestClient {
 
                 // attach statusCode and body obj (if available) to the error object
                 err['statusCode'] = statusCode;
-                if (rres.result) {
-                    err['result'] = rres.result;
+                if (response.result) {
+                    err['result'] = response.result;
                 }
 
                 reject(err);
             } else {
-                resolve(rres);
+                resolve(response);
             }
         });
     }

--- a/lib/RestClient.ts
+++ b/lib/RestClient.ts
@@ -9,7 +9,7 @@ import util = require("./Util");
 
 export interface IRestResponse<T> {
     statusCode: number,
-    result: T
+    result: T | null
 }
 
 export interface IRequestOptions {

--- a/test/resttests.ts
+++ b/test/resttests.ts
@@ -130,7 +130,7 @@ describe('Rest Tests', function () {
             let restRes: restm.IRestResponse<HttpBinData> = await _rest.get<HttpBinData>('https://httpbin.org/status/404');
             
             assert(restRes.statusCode == 404, "statusCode should be 404");
-            assert(restRes.result == null, "object should be null");
+            assert(restRes.result === null, "object should be null");
         }
         catch(err) {
             assert(false, "should not throw");

--- a/test/resttests.ts
+++ b/test/resttests.ts
@@ -28,7 +28,7 @@ describe('Rest Tests', function () {
 
     it('constructs', () => {
         this.timeout(1000);
-        
+
         let rest: restm.RestClient = new restm.RestClient('typed-test-client-tests');
         assert(rest, 'rest client should not be null');
     })
@@ -38,75 +38,75 @@ describe('Rest Tests', function () {
 
         let restRes: restm.IRestResponse<HttpBinData> = await _rest.get<HttpBinData>('https://httpbin.org/get');
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result.url === 'https://httpbin.org/get');
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/get');
     });
 
     it('gets a resource with baseUrl', async() => {
         let restRes: restm.IRestResponse<HttpBinData> = await _restBin.get<HttpBinData>('get');
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result.url === 'https://httpbin.org/get');
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/get');
     });
-    
+
     it('creates a resource', async() => {
         let res: any = { name: 'foo' };
         let restRes: restm.IRestResponse<HttpBinData> = await _rest.create<HttpBinData>('https://httpbin.org/post', res);
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result.url === 'https://httpbin.org/post');
-        assert(restRes.result.json.name === 'foo');
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/post');
+        assert(restRes.result && restRes.result.json.name === 'foo');
     });
-    
+
     it('creates a resource with a baseUrl', async() => {
         let res: any = { name: 'foo' };
         let restRes: restm.IRestResponse<HttpBinData> = await _restBin.create<HttpBinData>('post', res);
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result.url === 'https://httpbin.org/post');
-        assert(restRes.result.json.name === 'foo');
-    }); 
-    
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/post');
+        assert(restRes.result && restRes.result.json.name === 'foo');
+    });
+
     it('replaces a resource', async() => {
         let res: any = { name: 'foo' };
         let restRes: restm.IRestResponse<HttpBinData> = await _rest.replace<HttpBinData>('https://httpbin.org/put', res);
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result.url === 'https://httpbin.org/put');
-        assert(restRes.result.json.name === 'foo');
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/put');
+        assert(restRes.result && restRes.result.json.name === 'foo');
     });
-    
+
     it('replaces a resource with a baseUrl', async() => {
         let res: any = { name: 'foo' };
         let restRes: restm.IRestResponse<HttpBinData> = await _restBin.replace<HttpBinData>('put', res);
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result.url === 'https://httpbin.org/put');
-        assert(restRes.result.json.name === 'foo');
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/put');
+        assert(restRes.result && restRes.result.json.name === 'foo');
     });
-    
+
     it('updates a resource', async() => {
         let res: any = { name: 'foo' };
         let restRes: restm.IRestResponse<HttpBinData> = await _rest.update<HttpBinData>('https://httpbin.org/patch', res);
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result.url === 'https://httpbin.org/patch');
-        assert(restRes.result.json.name === 'foo');
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/patch');
+        assert(restRes.result && restRes.result.json.name === 'foo');
     });
-    
+
     it('updates a resource with a baseUrl', async() => {
         let res: any = { name: 'foo' };
         let restRes: restm.IRestResponse<HttpBinData> = await _restBin.update<HttpBinData>('patch', res);
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result.url === 'https://httpbin.org/patch');
-        assert(restRes.result.json.name === 'foo');
-    });    
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/patch');
+        assert(restRes.result && restRes.result.json.name === 'foo');
+    });
 
     it('deletes a resource', async() => {
         let restRes: restm.IRestResponse<HttpBinData> = await _rest.del<HttpBinData>('https://httpbin.org/delete');
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result.url === 'https://httpbin.org/delete');
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/delete');
     });
 
     it('deletes a resource with a baseUrl', async() => {
         let restRes: restm.IRestResponse<HttpBinData> = await _restBin.del<HttpBinData>('delete');
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result.url === 'https://httpbin.org/delete');
-    }); 
-    
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/delete');
+    });
+
     it('does an options request', async() => {
         let restRes: restm.IRestResponse<HttpBinData> = await _rest.options<HttpBinData>('https://httpbin.org');
         assert(restRes.statusCode == 200, "statusCode should be 200");
@@ -115,7 +115,7 @@ describe('Rest Tests', function () {
     it('does an options request with baseUrl', async() => {
         let restRes: restm.IRestResponse<HttpBinData> = await _restBin.options<HttpBinData>('');
         assert(restRes.statusCode == 200, "statusCode should be 200");
-    });    
+    });
 
     //----------------------------------------------
     // Get Error Cases
@@ -128,7 +128,7 @@ describe('Rest Tests', function () {
     it('gets a non-existant resource (404)', async() => {
         try {
             let restRes: restm.IRestResponse<HttpBinData> = await _rest.get<HttpBinData>('https://httpbin.org/status/404');
-            
+
             assert(restRes.statusCode == 404, "statusCode should be 404");
             assert(restRes.result === null, "object should be null");
         }
@@ -141,7 +141,7 @@ describe('Rest Tests', function () {
     // Unauthorized (401)
     // should throw and attach statusCode to the Error object
     // err.message is message proerty of resourceful error object or if not supplied, a generic error message
-    //    
+    //
     it('gets and handles unauthorized (401)', async() => {
         try {
             let restRes: restm.IRestResponse<HttpBinData> = await _rest.get<HttpBinData>('https://httpbin.org/status/401');
@@ -151,13 +151,13 @@ describe('Rest Tests', function () {
             assert(err['statusCode'] == 401, "statusCode should be 401");
             assert(err.message && err.message.length > 0, "should have error message");
         }
-    });    
-    
+    });
+
     //
     // Internal Server Error
     // should throw and attach statusCode to the Error object
     // err.message is message proerty of resourceful error object or if not supplied, a generic error message
-    //    
+    //
     it('gets and handles a server error (500)', async() => {
         try {
             let restRes: restm.IRestResponse<HttpBinData> = await _rest.get<HttpBinData>('https://httpbin.org/status/500');
@@ -183,7 +183,7 @@ describe('Rest Tests', function () {
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result.url === 'https://httpbin.org/anything/anythingextra');
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/anything/anythingextra');
     });
 
     it('maintains the path from the base url with no slashes', async() => {
@@ -195,7 +195,7 @@ describe('Rest Tests', function () {
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result.url === 'https://httpbin.org/anything/anythingextra');
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/anything/anythingextra');
     });
 
     it('maintains the path from the base url with double slashes', async() => {
@@ -207,7 +207,7 @@ describe('Rest Tests', function () {
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result.url === 'https://httpbin.org/anything/anythingextra');
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/anything/anythingextra');
     });
 
     it('maintains the path from the base url with multiple parts', async() => {
@@ -219,7 +219,7 @@ describe('Rest Tests', function () {
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result.url === 'https://httpbin.org/anything/extrapart/anythingextra');
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/anything/extrapart/anythingextra');
     });
 
     it('maintains the path from the base url where request has multiple parts', async() => {
@@ -231,7 +231,7 @@ describe('Rest Tests', function () {
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result.url === 'https://httpbin.org/anything/anythingextra/moreparts');
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/anything/anythingextra/moreparts');
     });
 
     it('maintains the path from the base url where both have multiple parts', async() => {
@@ -243,7 +243,7 @@ describe('Rest Tests', function () {
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result.url === 'https://httpbin.org/anything/multiple/anythingextra/moreparts');
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/anything/multiple/anythingextra/moreparts');
     });
 
     it('maintains the path from the base url where request has query parameters', async() => {
@@ -255,9 +255,9 @@ describe('Rest Tests', function () {
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result.url === 'https://httpbin.org/anything/multiple/anythingextra/moreparts?foo=bar&baz=top');
-        assert(restRes.result.args.foo === 'bar');
-        assert(restRes.result.args.baz === 'top');
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/anything/multiple/anythingextra/moreparts?foo=bar&baz=top');
+        assert(restRes.result && restRes.result.args.foo === 'bar');
+        assert(restRes.result && restRes.result.args.baz === 'top');
     });
 
     //
@@ -272,11 +272,11 @@ describe('Rest Tests', function () {
         let res: string = util.getUrl('', 'http://httpbin.org');
         assert(res === 'http://httpbin.org', "should be http://httpbin.org");
     });
-    
+
     it('resolves a null resource with baseUrl', async() => {
         let res: string = util.getUrl(null, 'http://httpbin.org');
         assert(res === 'http://httpbin.org', "should be http://httpbin.org");
-    });    
+    });
 
     it('resolves a full resource and no baseUrl', async() => {
         let res: string = util.getUrl('http://httpbin.org/get?x=y&a=b');
@@ -291,7 +291,7 @@ describe('Rest Tests', function () {
     it('resolves a relative path resource with host baseUrl', async() => {
         let res: string = util.getUrl('get/foo', 'http://httpbin.org');
         assert(res === 'http://httpbin.org/get/foo', `should be http://httpbin.org/get/foo but is ${res}`);
-    });    
+    });
 
     it('resolves a rooted path resource with pathed baseUrl', async() => {
         let res: string = util.getUrl('/get/foo', 'http://httpbin.org/bar');


### PR DESCRIPTION
This PR changes `RestClient._processResult()` to return a null result to match the behavior of the documentation. It previously returned `undefined`. It also updates the signaure of `RestResponse<T>` accordingly.