### PR TITLE
Removes the setting of the default port if one isn't specified.

### DIFF
--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -329,10 +329,9 @@ export class HttpClient implements ifm.IHttpClient {
         info.parsedUrl = url.parse(requestUrl);
         const usingSsl: boolean = info.parsedUrl.protocol === 'https:';
         info.httpModule = usingSsl ? https : http;
-        const defaultPort: number = usingSsl ? 443 : 80;
         info.options = <http.RequestOptions>{};
         info.options.host = info.parsedUrl.hostname;
-        info.options.port = info.parsedUrl.port ? parseInt(info.parsedUrl.port) : defaultPort;
+        info.options.port = info.parsedUrl.port ? parseInt(info.parsedUrl.port) : undefined;
         info.options.path = (info.parsedUrl.pathname || '') + (info.parsedUrl.search || '');
         info.options.method = method;
         info.options.headers = headers || {};


### PR DESCRIPTION
This fixes behavior where a baseUrl isn't defined and we expect the
client to fetch based on the current root url whilst running in the
browser.

Referenced in issue #66 .