### PR TITLE
Handle 303 SeeOther redirect.

### DIFF
--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -13,6 +13,7 @@ export enum HttpCodes {
     MultipleChoices = 300,
     MovedPermanently = 301,
     ResourceMoved = 302,
+    SeeOther = 303,
     NotModified = 304,
     UseProxy = 305,
     SwitchProxy = 306,
@@ -36,7 +37,7 @@ export enum HttpCodes {
     GatewayTimeout = 504,
 }
 
-const HttpRedirectCodes: number[] = [HttpCodes.MovedPermanently, HttpCodes.ResourceMoved, HttpCodes.TemporaryRedirect, HttpCodes.PermanentRedirect];
+const HttpRedirectCodes: number[] = [HttpCodes.MovedPermanently, HttpCodes.ResourceMoved, HttpCodes.SeeOther, HttpCodes.TemporaryRedirect, HttpCodes.PermanentRedirect];
 
 export class HttpClientResponse implements ifm.IHttpClientResponse {
     constructor(message: http.IncomingMessage) {

--- a/test/httptests.ts
+++ b/test/httptests.ts
@@ -101,6 +101,14 @@ describe('Http Tests', function () {
         let obj:any = JSON.parse(body);
         assert(obj.url === "https://httpbin.org/get");
     });
+
+    it('does basic get request with redirects (303)', async() => {
+        let res: httpm.HttpClientResponse = await _http.get("https://httpbin.org/redirect-to?url=" + encodeURIComponent("https://httpbin.org/get") + '&status_code=303')
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();
+        let obj:any = JSON.parse(body);
+        assert(obj.url === "https://httpbin.org/get");
+    });
     
     it('does not follow redirects if disabled', async() => {
         let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests', null, { allowRedirects: false });
@@ -108,7 +116,7 @@ describe('Http Tests', function () {
         assert(res.message.statusCode == 302, "status code should be 302");
         let body: string = await res.readBody();
     });
-    
+
     it('does basic head request', async() => {
         let res: httpm.HttpClientResponse = await _http.head('http://httpbin.org/get');
         assert(res.message.statusCode == 200, "status code should be 200");

--- a/test/httptests.ts
+++ b/test/httptests.ts
@@ -109,7 +109,13 @@ describe('Http Tests', function () {
         let obj:any = JSON.parse(body);
         assert(obj.url === "https://httpbin.org/get");
     });
-    
+
+    it('returns 404 for not found get request on redirect', async() => {
+        let res: httpm.HttpClientResponse = await _http.get("https://httpbin.org/redirect-to?url=" + encodeURIComponent("http://httpbin.org/status/404") + '&status_code=303')
+        assert(res.message.statusCode == 404, "status code should be 404");
+        let body: string = await res.readBody();
+    });
+
     it('does not follow redirects if disabled', async() => {
         let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests', null, { allowRedirects: false });
         let res: httpm.HttpClientResponse = await http.get("https://httpbin.org/redirect-to?url=" + encodeURIComponent("https://httpbin.org/get"))


### PR DESCRIPTION
Implementation is missing 303 redirect support.

I am facing issue downloading a file from a resource which is using this redirect to point to the actual resource.