### PR TITLE
Updated tests to use Nock instead of httpBin

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,25 @@ latest preview:
 npm install typed-rest-client@preview --save
 ```
 
+# Build
+
+Build:  
+```bash
+$ npm run build
+```
+
+# Test
+
+To run all tests:
+```bash
+$ npm test
+```
+
+To just run unit tests:
+```bash
+$ npm run units
+```
+
 ## Samples
 
 See [samples](./samples) for complete coding examples

--- a/make.js
+++ b/make.js
@@ -65,14 +65,30 @@ target.build = function () {
     cp(rp('ThirdPartyNotice.txt'), buildPath);
 }
 
+target.units = function() {
+    // install the just built lib into the test proj
+    pushd('test')
+    run('npm install ../_build');
+    popd();
+
+    console.log("-------Unit Tests-------");
+    run('tsc -p ./test/units');
+    run('mocha test/units');
+}
+
 target.test = function() {
     // install the just built lib into the test proj
     pushd('test')
     run('npm install ../_build');
     popd();
 
-    run('tsc -p ./test');
-    run('mocha test');
+    console.log("-------Unit Tests-------");
+    run('tsc -p ./test/units');
+    run('mocha test/units');
+
+    console.log("-------Other Tests-------");
+    run('tsc -p ./test/tests');
+    run('mocha test/tests');
 }
 
 target.buildtest = function() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,11 @@
         "@types/node": "6.0.92"
       }
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -63,6 +68,24 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
+    },
+    "chai": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "requires": {
+        "assertion-error": "1.1.0",
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.8"
+      }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
     },
     "commander": {
       "version": "2.9.0",
@@ -88,6 +111,19 @@
         "ms": "2.0.0"
       }
     },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+    },
     "diff": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
@@ -105,6 +141,11 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
     },
     "glob": {
       "version": "7.1.1",
@@ -166,11 +207,21 @@
       "integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA=",
       "dev": true
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
     "json3": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
+    },
+    "lodash": {
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -252,14 +303,12 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -287,8 +336,38 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "nock": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-9.6.1.tgz",
+      "integrity": "sha512-EDgl/WgNQ0C1BZZlASOQkQdE6tAWXJi8QQlugqzN64JJkvZ7ILijZuG24r4vCC7yOfnm6HKpne5AGExLGCeBWg==",
+      "requires": {
+        "chai": "4.1.2",
+        "debug": "3.1.0",
+        "deep-equal": "1.0.1",
+        "json-stringify-safe": "5.0.1",
+        "lodash": "4.17.10",
+        "mkdirp": "0.5.1",
+        "propagate": "1.0.0",
+        "qs": "6.5.2",
+        "semver": "5.5.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "semver": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+          "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
+        }
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -310,6 +389,21 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+    },
+    "propagate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
+      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk="
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "rechoir": {
       "version": "0.6.2",
@@ -359,6 +453,11 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
       "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "typescript": {
       "version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "typescript": "2.4.2"
   },
   "dependencies": {
+    "nock": "9.6.1",
     "tunnel": "0.0.4",
     "underscore": "1.8.3"
   }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "node make.js test",
     "bt": "node make.js buildtest",
     "samples": "node make.js samples",
+    "units": "node make.js units",
     "validate": "node make.js validate"
   },
   "repository": {

--- a/test/httptests.ts
+++ b/test/httptests.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import assert = require('assert');
+import nock = require('nock');
 import * as httpm from 'typed-rest-client/HttpClient';
 import * as hm from 'typed-rest-client/Handlers';
 import * as fs from 'fs';
@@ -11,7 +12,6 @@ let sampleFilePath: string = path.join(__dirname, 'testoutput.txt');
 
 describe('Http Tests', function () {
     let _http: httpm.HttpClient;
-    let _httpbin: httpm.HttpClient;
 
     before(() => {
         _http = new httpm.HttpClient('typed-test-client-tests');
@@ -20,6 +20,10 @@ describe('Http Tests', function () {
     after(() => {
     });
 
+    afterEach(() => {
+        nock.cleanAll();
+    })
+
     it('constructs', () => {
         this.timeout(1000);
 
@@ -27,142 +31,229 @@ describe('Http Tests', function () {
         assert(http, 'http client should not be null');
     });
 
-    // responses from httpbin return something like:
-    // {
-    //     "args": {}, 
-    //     "headers": {
-    //       "Connection": "close", 
-    //       "Host": "httpbin.org", 
-    //       "User-Agent": "typed-test-client-tests"
-    //     }, 
-    //     "origin": "173.95.152.44", 
-    //     "url": "https://httpbin.org/get"
-    //  }  
     it('does basic http get request', async() => {
-        let res: httpm.HttpClientResponse = await _http.get('http://httpbin.org/get');
+        nock('http://microsoft.com')
+            .get('/')
+            .reply(200, {
+                source: "nock"
+            });
+        let res: httpm.HttpClientResponse = await _http.get('http://microsoft.com');
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody();      
-        let obj:any = JSON.parse(body);
-        assert(obj.url === "http://httpbin.org/get");
-    });
-
-    it('does basic https get request', async() => {
-        let res: httpm.HttpClientResponse = await _http.get('https://httpbin.org/get');
-        assert(res.message.statusCode == 200, "status code should be 200");
-        let body: string = await res.readBody();
-        let obj:any = JSON.parse(body);
-        assert(obj.url === "https://httpbin.org/get");
-    });
+        let obj: any = JSON.parse(body);
+        assert(obj.source === "nock", "http get request should be intercepted by nock");
+    })
 
     it('does basic http get request with basic auth', async() => {
+        //Set nock for correct credentials
+        nock('http://microsoft.com')
+            .get('/')
+            .basicAuth({
+                user: 'johndoe',
+                pass: 'password'
+            })
+            .reply(200, {
+                success: true,
+                source: "nock"
+            });
+        //Set nock for request without credentials or with incorrect credentials
+        nock('http://microsoft.com')
+            .get('/')
+            .reply(200, {
+                success: false,
+                source: "nock"
+            });
         let bh: hm.BasicCredentialHandler = new hm.BasicCredentialHandler('johndoe', 'password');
         let http: httpm.HttpClient = new httpm.HttpClient('typed-rest-client-tests', [bh]);
-        let res: httpm.HttpClientResponse = await http.get('http://httpbin.org/get');
+        let res: httpm.HttpClientResponse = await http.get('http://microsoft.com');
         assert(res.message.statusCode == 200, "status code should be 200");
-        let body: string = await res.readBody(); 
-        let obj:any = JSON.parse(body);
-        let auth: string = obj.headers.Authorization;
-        let creds: string = Buffer.from(auth.substring('Basic '.length), 'base64').toString();
-        assert(creds === 'johndoe:password', "should be the username and password");
-        assert(obj.url === "http://httpbin.org/get");
+        let body: string = await res.readBody();      
+        let obj: any = JSON.parse(body);
+        assert(obj.source === "nock", "http get request should be intercepted by nock");
+        assert(obj.success, "Authentication should succeed");
     });
     
     it('does basic http get request with pat token auth', async() => {
         let token: string = 'scbfb44vxzku5l4xgc3qfazn3lpk4awflfryc76esaiq7aypcbhs';
+        let pat: string = new Buffer('PAT:' + token).toString('base64')
+        //Set nock for correct credentials
+        nock('http://microsoft.com', {
+            reqheaders: {
+                'Authorization': 'Basic ' + pat,
+                'X-TFS-FedAuthRedirect': 'Suppress'
+            }})
+            .get('/')
+            .reply(200, {
+                success: true,
+                source: "nock"
+            });
+        //Set nock for request without credentials or with incorrect credentials
+        nock('http://microsoft.com')
+            .get('/')
+            .reply(200, {
+                success: false,
+                source: "nock"
+            });
         let ph: hm.PersonalAccessTokenCredentialHandler = 
             new hm.PersonalAccessTokenCredentialHandler(token);
         let http: httpm.HttpClient = new httpm.HttpClient('typed-rest-client-tests', [ph]);
-        let res: httpm.HttpClientResponse = await http.get('http://httpbin.org/get');
+        let res: httpm.HttpClientResponse = await http.get('http://microsoft.com');
         assert(res.message.statusCode == 200, "status code should be 200");
-        let body: string = await res.readBody(); 
-        let obj:any = JSON.parse(body);
-        let auth: string = obj.headers.Authorization;
-        let creds: string = Buffer.from(auth.substring('Basic '.length), 'base64').toString();
-        assert(creds === 'PAT:' + token, "creds should be the token");
-        assert(obj.url === "http://httpbin.org/get");
+        let body: string = await res.readBody();      
+        let obj: any = JSON.parse(body);
+        assert(obj.source === "nock", "http get request should be intercepted by nock");
+        assert(obj.success, "Authentication should succeed");
     });
 
     it('pipes a get request', () => {
+        nock('http://microsoft.com')
+            .get('/')
+            .reply(200, {
+                url: "http://microsoft.com"
+            });
         return new Promise<string>(async (resolve, reject) => {
             let file: NodeJS.WritableStream = fs.createWriteStream(sampleFilePath);
-            (await _http.get('https://httpbin.org/get')).message.pipe(file).on('close', () => {
+            (await _http.get('http://microsoft.com')).message.pipe(file).on('close', () => {
                 let body: string = fs.readFileSync(sampleFilePath).toString();
                 let obj:any = JSON.parse(body);
-                assert(obj.url === "https://httpbin.org/get", "response from piped stream should have url");
+                assert(obj.url === "http://microsoft.com", "response from piped stream should have url");
                 resolve();
             });
         });
     });
     
     it('does basic get request with redirects', async() => {
-        let res: httpm.HttpClientResponse = await _http.get("https://httpbin.org/redirect-to?url=" + encodeURIComponent("https://httpbin.org/get"))
+        nock('http://microsoft.com')
+            .get('/redirect-to')
+            .reply(301, undefined, {
+                location:'http://microsoft.com'
+            });
+        nock('http://microsoft.com')
+            .get('/')
+            .reply(200, {
+                source: "nock"
+            });
+        let res: httpm.HttpClientResponse = await _http.get('http://microsoft.com/redirect-to');
         assert(res.message.statusCode == 200, "status code should be 200");
-        let body: string = await res.readBody();
-        let obj:any = JSON.parse(body);
-        assert(obj.url === "https://httpbin.org/get");
+        let body: string = await res.readBody();      
+        let obj: any = JSON.parse(body);
+        assert(obj.source === "nock", "request should redirect to mocked page");
     });
 
     it('does basic get request with redirects (303)', async() => {
-        let res: httpm.HttpClientResponse = await _http.get("https://httpbin.org/redirect-to?url=" + encodeURIComponent("https://httpbin.org/get") + '&status_code=303')
+        nock('http://microsoft.com')
+            .get('/redirect-to')
+            .reply(303, undefined, {
+                location:'http://microsoft.com'
+            });
+        nock('http://microsoft.com')
+            .get('/')
+            .reply(200, {
+                source: "nock"
+            });
+        let res: httpm.HttpClientResponse = await _http.get('http://microsoft.com/redirect-to');
         assert(res.message.statusCode == 200, "status code should be 200");
-        let body: string = await res.readBody();
-        let obj:any = JSON.parse(body);
-        assert(obj.url === "https://httpbin.org/get");
+        let body: string = await res.readBody();      
+        let obj: any = JSON.parse(body);
+        assert(obj.source === "nock", "request should redirect to mocked page");
     });
 
     it('returns 404 for not found get request on redirect', async() => {
-        let res: httpm.HttpClientResponse = await _http.get("https://httpbin.org/redirect-to?url=" + encodeURIComponent("http://httpbin.org/status/404") + '&status_code=303')
-        assert(res.message.statusCode == 404, "status code should be 404");
-        let body: string = await res.readBody();
+        nock('http://microsoft.com')
+        .get('/redirect-to')
+        .reply(301, undefined, {
+            location:'http://badmicrosoft.com'
+        });
+    nock('http://badmicrosoft.com')
+        .get('/')
+        .reply(404, {
+            source: "nock"
+        });
+    let res: httpm.HttpClientResponse = await _http.get('http://microsoft.com/redirect-to');
+    assert(res.message.statusCode == 404, "status code should be 404");
+    let body: string = await res.readBody();      
+    let obj: any = JSON.parse(body);
+    assert(obj.source === "nock", "request should redirect to mocked missing");
     });
 
     it('does not follow redirects if disabled', async() => {
+        nock('http://microsoft.com')
+        .get('/redirect-to')
+        .reply(302, undefined, {
+            location:'http://microsoft.com'
+        });
+        nock('http://microsoft.com')
+            .get('/')
+            .reply(200, {
+                source: "nock"
+            });
         let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests', null, { allowRedirects: false });
-        let res: httpm.HttpClientResponse = await http.get("https://httpbin.org/redirect-to?url=" + encodeURIComponent("https://httpbin.org/get"))
+        let res: httpm.HttpClientResponse = await http.get('http://microsoft.com/redirect-to');
         assert(res.message.statusCode == 302, "status code should be 302");
         let body: string = await res.readBody();
     });
 
     it('does basic head request', async() => {
-        let res: httpm.HttpClientResponse = await _http.head('http://httpbin.org/get');
+        nock('http://microsoft.com')
+            .head('/')
+            .reply(200, {
+                source: "nock"
+            });
+        let res: httpm.HttpClientResponse = await _http.head('http://microsoft.com');
         assert(res.message.statusCode == 200, "status code should be 200");
     });
 
     it('does basic http delete request', async() => {
-        let res: httpm.HttpClientResponse = await _http.del('http://httpbin.org/delete');
+        nock('http://microsoft.com')
+            .delete('/')
+            .reply(200, {
+                source: "nock"
+            });
+        let res: httpm.HttpClientResponse = await _http.del('http://microsoft.com');
         assert(res.message.statusCode == 200, "status code should be 200");
-        let body: string = await res.readBody();      
-        let obj:any = JSON.parse(body);
     });
 
     it('does basic http post request', async() => {
+        nock('http://microsoft.com')
+            .post('/')
+            .reply(200, function(uri, requestBody) {
+                return {data: requestBody};
+            });
         let b: string = 'Hello World!';
-        let res: httpm.HttpClientResponse = await _http.post('http://httpbin.org/post', b);
+        let res: httpm.HttpClientResponse = await _http.post('http://microsoft.com', b);
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody();
         let obj:any = JSON.parse(body);
         assert(obj.data === b);
-        assert(obj.url === "http://httpbin.org/post");
     });
     
     it('does basic http patch request', async() => {
+        nock('http://microsoft.com')
+            .patch('/')
+            .reply(200, function(uri, requestBody) {
+                return {data: requestBody};
+            });
         let b: string = 'Hello World!';
-        let res: httpm.HttpClientResponse = await _http.patch('http://httpbin.org/patch', b);
+        let res: httpm.HttpClientResponse = await _http.patch('http://microsoft.com', b);
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody();
         let obj:any = JSON.parse(body);
         assert(obj.data === b);
-        assert(obj.url === "http://httpbin.org/patch");
     });
     
     it('does basic http options request', async() => {
-        let res: httpm.HttpClientResponse = await _http.options('http://httpbin.org');
+        nock('http://microsoft.com')
+            .options('/')
+            .reply(200);
+        let res: httpm.HttpClientResponse = await _http.options('http://microsoft.com');
         assert(res.message.statusCode == 200, "status code should be 200");
-        let body: string = await res.readBody();
     });
     
     it('returns 404 for not found get request', async() => {
-        let res: httpm.HttpClientResponse = await _http.get('http://httpbin.org/status/404');
+        nock('http://badmicrosoft.com')
+            .get('/')
+            .reply(404);
+        let res: httpm.HttpClientResponse = await _http.get('http://badmicrosoft.com');
         assert(res.message.statusCode == 404, "status code should be 404");
         let body: string = await res.readBody();
     });
@@ -179,48 +270,71 @@ describe('Http Tests with keepAlive', function () {
     });
 
     it('does basic http get request with keepAlive true', async() => {
-        let res: httpm.HttpClientResponse = await _http.get('http://httpbin.org/get');
+        nock('http://microsoft.com')
+            .get('/')
+            .reply(200, {
+                source: "nock"
+            });
+        let res: httpm.HttpClientResponse = await _http.get('http://microsoft.com');
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody();      
-        let obj:any = JSON.parse(body);
-        assert(obj.url === "http://httpbin.org/get");
+        let obj: any = JSON.parse(body);
+        assert(obj.source === "nock", "http get request should be intercepted by nock");
     });
 
     it('does basic head request with keepAlive true', async() => {
-        let res: httpm.HttpClientResponse = await _http.head('http://httpbin.org/get');
+        nock('http://microsoft.com')
+            .head('/')
+            .reply(200, {
+                source: "nock"
+            });
+        let res: httpm.HttpClientResponse = await _http.head('http://microsoft.com');
         assert(res.message.statusCode == 200, "status code should be 200");
     });    
 
     it('does basic http delete request with keepAlive true', async() => {
-        let res: httpm.HttpClientResponse = await _http.del('http://httpbin.org/delete');
+        nock('http://microsoft.com')
+            .delete('/')
+            .reply(200, {
+                source: "nock"
+            });
+        let res: httpm.HttpClientResponse = await _http.del('http://microsoft.com');
         assert(res.message.statusCode == 200, "status code should be 200");
-        let body: string = await res.readBody();      
-        let obj:any = JSON.parse(body);
     });
 
     it('does basic http post request with keepAlive true', async() => {
+        nock('http://microsoft.com')
+            .post('/')
+            .reply(200, function(uri, requestBody) {
+                return {data: requestBody};
+            });
         let b: string = 'Hello World!';
-        let res: httpm.HttpClientResponse = await _http.post('http://httpbin.org/post', b);
+        let res: httpm.HttpClientResponse = await _http.post('http://microsoft.com', b);
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody();
         let obj:any = JSON.parse(body);
         assert(obj.data === b);
-        assert(obj.url === "http://httpbin.org/post");
     });
     
     it('does basic http patch request with keepAlive true', async() => {
+        nock('http://microsoft.com')
+            .patch('/')
+            .reply(200, function(uri, requestBody) {
+                return {data: requestBody};
+            });
         let b: string = 'Hello World!';
-        let res: httpm.HttpClientResponse = await _http.patch('http://httpbin.org/patch', b);
+        let res: httpm.HttpClientResponse = await _http.patch('http://microsoft.com', b);
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody();
         let obj:any = JSON.parse(body);
         assert(obj.data === b);
-        assert(obj.url === "http://httpbin.org/patch");
     }); 
     
     it('does basic http options request with keepAlive true', async() => {
-        let res: httpm.HttpClientResponse = await _http.options('http://httpbin.org');
+        nock('http://microsoft.com')
+            .options('/')
+            .reply(200);
+        let res: httpm.HttpClientResponse = await _http.options('http://microsoft.com');
         assert(res.message.statusCode == 200, "status code should be 200");
-        let body: string = await res.readBody();
     });
 });

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -7,12 +7,113 @@
     "typed-rest-client": {
       "version": "file:../_build",
       "requires": {
+        "nock": "9.6.1",
         "tunnel": "0.0.4",
         "underscore": "1.8.3"
       },
       "dependencies": {
+        "assertion-error": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "chai": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "assertion-error": "1.1.0",
+            "check-error": "1.0.2",
+            "deep-eql": "3.0.1",
+            "get-func-name": "2.0.0",
+            "pathval": "1.1.0",
+            "type-detect": "4.0.8"
+          }
+        },
+        "check-error": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-eql": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "type-detect": "4.0.8"
+          }
+        },
+        "deep-equal": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "get-func-name": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "bundled": true
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "nock": {
+          "version": "9.6.1",
+          "bundled": true,
+          "requires": {
+            "chai": "4.1.2",
+            "debug": "3.1.0",
+            "deep-equal": "1.0.1",
+            "json-stringify-safe": "5.0.1",
+            "lodash": "4.17.10",
+            "mkdirp": "0.5.1",
+            "propagate": "1.0.0",
+            "qs": "6.5.2",
+            "semver": "5.5.1"
+          }
+        },
+        "pathval": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "propagate": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "qs": {
+          "version": "6.5.2",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.5.1",
+          "bundled": true
+        },
         "tunnel": {
           "version": "0.0.4",
+          "bundled": true
+        },
+        "type-detect": {
+          "version": "4.0.8",
           "bundled": true
         },
         "underscore": {

--- a/test/resttests.ts
+++ b/test/resttests.ts
@@ -2,12 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import assert = require('assert');
+import nock = require('nock');
 import * as restm from 'typed-rest-client/RestClient';
 import * as util from 'typed-rest-client/Util';
-import * as fs from 'fs';
-import * as path from 'path';
 
-export interface HttpBinData {
+export interface HttpData {
     url: string;
     data: any;
     json: any;
@@ -17,14 +16,20 @@ export interface HttpBinData {
 describe('Rest Tests', function () {
     let _rest: restm.RestClient;
     let _restBin: restm.RestClient;
+    let _restMic: restm.RestClient;
 
     before(() => {
         _rest = new restm.RestClient('typed-rest-client-tests');
         _restBin = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org');
+        _restMic = new restm.RestClient('typed-rest-client-tests', 'http://microsoft.com');
     });
 
     after(() => {
     });
+
+    afterEach(() => {
+        nock.cleanAll();
+    })
 
     it('constructs', () => {
         this.timeout(1000);
@@ -34,88 +39,186 @@ describe('Rest Tests', function () {
     })
 
     it('gets a resource', async() => {
-        this.timeout(3000);
-
-        let restRes: restm.IRestResponse<HttpBinData> = await _rest.get<HttpBinData>('https://httpbin.org/get');
+        nock('http://microsoft.com')
+            .get('/')
+            .reply(200, {
+                url: 'http://microsoft.com',
+                data: null,
+                json: null
+            });
+        let restRes: restm.IRestResponse<HttpData> = await _rest.get<HttpData>('http://microsoft.com');
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/get');
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com');
     });
 
     it('gets a resource with baseUrl', async() => {
-        let restRes: restm.IRestResponse<HttpBinData> = await _restBin.get<HttpBinData>('get');
+        nock('http://microsoft.com')
+            .get('/')
+            .reply(200, {
+                url: 'http://microsoft.com',
+                data: null,
+                json: null
+            });
+        let restRes: restm.IRestResponse<HttpData> = await _restMic.get<HttpData>('');
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/get');
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com');
     });
 
     it('creates a resource', async() => {
+        nock('http://microsoft.com')
+            .post('/')
+            .reply(200, function(uri, requestBody) {
+                let body = JSON.parse(requestBody);
+                return {
+                    url: 'http://microsoft.com/post',
+                    data: null,
+                    json: body.name
+                };
+            });
         let res: any = { name: 'foo' };
-        let restRes: restm.IRestResponse<HttpBinData> = await _rest.create<HttpBinData>('https://httpbin.org/post', res);
+        let restRes: restm.IRestResponse<HttpData> = await _rest.create<HttpData>('http://microsoft.com', res);
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/post');
-        assert(restRes.result && restRes.result.json.name === 'foo');
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com/post');
+        assert(restRes.result && restRes.result.json === 'foo');
     });
 
     it('creates a resource with a baseUrl', async() => {
+        nock('http://microsoft.com')
+            .post('/')
+            .reply(200, function(uri, requestBody) {
+                let body = JSON.parse(requestBody);
+                return {
+                    url: 'http://microsoft.com/post',
+                    data: null,
+                    json: body.name
+                };
+            });
         let res: any = { name: 'foo' };
-        let restRes: restm.IRestResponse<HttpBinData> = await _restBin.create<HttpBinData>('post', res);
+        let restRes: restm.IRestResponse<HttpData> = await _restMic.create<HttpData>('', res);
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/post');
-        assert(restRes.result && restRes.result.json.name === 'foo');
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com/post');
+        assert(restRes.result && restRes.result.json === 'foo');
     });
 
     it('replaces a resource', async() => {
-        this.timeout(3000);
-
+        nock('http://microsoft.com')
+            .put('/')
+            .reply(200, function(uri, requestBody) {
+                let body = JSON.parse(requestBody);
+                return {
+                    url: 'http://microsoft.com/put',
+                    data: null,
+                    json: body.name
+                };
+            });
         let res: any = { name: 'foo' };
-        let restRes: restm.IRestResponse<HttpBinData> = await _rest.replace<HttpBinData>('https://httpbin.org/put', res);
+        let restRes: restm.IRestResponse<HttpData> = await _rest.replace<HttpData>('http://microsoft.com', res);
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/put');
-        assert(restRes.result && restRes.result.json.name === 'foo');
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com/put');
+        assert(restRes.result && restRes.result.json === 'foo');
     });
 
     it('replaces a resource with a baseUrl', async() => {
+        nock('http://microsoft.com')
+            .put('/')
+            .reply(200, function(uri, requestBody) {
+                let body = JSON.parse(requestBody);
+                return {
+                    url: 'http://microsoft.com/put',
+                    data: null,
+                    json: body.name
+                };
+            });
         let res: any = { name: 'foo' };
-        let restRes: restm.IRestResponse<HttpBinData> = await _restBin.replace<HttpBinData>('put', res);
+        let restRes: restm.IRestResponse<HttpData> = await _restMic.replace<HttpData>('', res);
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/put');
-        assert(restRes.result && restRes.result.json.name === 'foo');
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com/put');
+        assert(restRes.result && restRes.result.json === 'foo');
     });
 
     it('updates a resource', async() => {
+        nock('http://microsoft.com')
+            .put('/')
+            .reply(200, function(uri, requestBody) {
+                let body = JSON.parse(requestBody);
+                return {
+                    url: 'http://microsoft.com/put',
+                    data: null,
+                    json: body.name
+                };
+            });
         let res: any = { name: 'foo' };
-        let restRes: restm.IRestResponse<HttpBinData> = await _rest.update<HttpBinData>('https://httpbin.org/patch', res);
+        let restRes: restm.IRestResponse<HttpData> = await _rest.replace<HttpData>('http://microsoft.com', res);
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/patch');
-        assert(restRes.result && restRes.result.json.name === 'foo');
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com/put');
+        assert(restRes.result && restRes.result.json === 'foo');
     });
 
     it('updates a resource with a baseUrl', async() => {
+        nock('http://microsoft.com')
+            .put('/')
+            .reply(200, function(uri, requestBody) {
+                let body = JSON.parse(requestBody);
+                return {
+                    url: 'http://microsoft.com/put',
+                    data: null,
+                    json: body.name
+                };
+            });
         let res: any = { name: 'foo' };
-        let restRes: restm.IRestResponse<HttpBinData> = await _restBin.update<HttpBinData>('patch', res);
+        let restRes: restm.IRestResponse<HttpData> = await _restMic.replace<HttpData>('', res);
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/patch');
-        assert(restRes.result && restRes.result.json.name === 'foo');
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com/put');
+        assert(restRes.result && restRes.result.json === 'foo');
     });
 
     it('deletes a resource', async() => {
-        let restRes: restm.IRestResponse<HttpBinData> = await _rest.del<HttpBinData>('https://httpbin.org/delete');
+        nock('http://microsoft.com')
+            .delete('/')
+            .reply(200, {
+                url: 'http://microsoft.com/delete',
+                data: null,
+                json: null
+            });
+        let restRes: restm.IRestResponse<HttpData> = await _rest.del<HttpData>('http://microsoft.com');
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/delete');
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com/delete');
     });
 
     it('deletes a resource with a baseUrl', async() => {
-        let restRes: restm.IRestResponse<HttpBinData> = await _restBin.del<HttpBinData>('delete');
+        nock('http://microsoft.com')
+            .delete('/')
+            .reply(200, {
+                url: 'http://microsoft.com/delete',
+                data: null,
+                json: null
+            });
+        let restRes: restm.IRestResponse<HttpData> = await _restMic.del<HttpData>('');
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/delete');
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com/delete');
     });
 
     it('does an options request', async() => {
-        let restRes: restm.IRestResponse<HttpBinData> = await _rest.options<HttpBinData>('https://httpbin.org');
+        nock('http://microsoft.com')
+            .options('/')
+            .reply(200, {
+                url: 'http://microsoft.com/options',
+                data: null,
+                json: null
+            });
+        let restRes: restm.IRestResponse<HttpData> = await _rest.options<HttpData>('http://microsoft.com');
         assert(restRes.statusCode == 200, "statusCode should be 200");
     });
 
     it('does an options request with baseUrl', async() => {
-        let restRes: restm.IRestResponse<HttpBinData> = await _restBin.options<HttpBinData>('');
+        nock('http://microsoft.com')
+            .options('/')
+            .reply(200, {
+                url: 'http://microsoft.com/options',
+                data: null,
+                json: null
+            });
+        let restRes: restm.IRestResponse<HttpData> = await _restMic.options<HttpData>('');
         assert(restRes.statusCode == 200, "statusCode should be 200");
     });
 
@@ -128,17 +231,19 @@ describe('Rest Tests', function () {
     // should return a null resource, 404 status, and should not throw
     //
     it('gets a non-existant resource (404)', async() => {
-        this.timeout(3000);
-
+        nock('http://microsoft.com')
+            .get('/status/404')
+            .reply(404);
+        let restRes: restm.IRestResponse<HttpData>;
         try {
-            let restRes: restm.IRestResponse<HttpBinData> = await _rest.get<HttpBinData>('https://httpbin.org/status/404');
-
-            assert(restRes.statusCode == 404, "statusCode should be 404");
-            assert(restRes.result === null, "object should be null");
+            restRes= await _rest.get<HttpData>('http://microsoft.com/status/404');
         }
         catch(err) {
-            assert(false, "should not throw");
+            console.log(err);
+            assert(false, "Request should succeed, should not throw");
         }
+        assert(restRes.statusCode == 404, "statusCode should be 404");
+        assert(restRes.result === null, "object should be null");
     });
 
     //
@@ -147,8 +252,11 @@ describe('Rest Tests', function () {
     // err.message is message proerty of resourceful error object or if not supplied, a generic error message
     //
     it('gets and handles unauthorized (401)', async() => {
+        nock('http://microsoft.com')
+            .get('/status/401')
+            .replyWithError({'message': 'something awful happened', 'statusCode': 401});
         try {
-            let restRes: restm.IRestResponse<HttpBinData> = await _rest.get<HttpBinData>('https://httpbin.org/status/401');
+            let restRes: restm.IRestResponse<HttpData> = await _rest.get<HttpData>('http://microsoft.com/status/401');
             assert(false, "should throw");
         }
         catch(err) {
@@ -163,8 +271,11 @@ describe('Rest Tests', function () {
     // err.message is message proerty of resourceful error object or if not supplied, a generic error message
     //
     it('gets and handles a server error (500)', async() => {
+        nock('http://microsoft.com')
+            .get('/status/500')
+            .replyWithError({'message': 'something awful happened', 'statusCode': 500});
         try {
-            let restRes: restm.IRestResponse<HttpBinData> = await _rest.get<HttpBinData>('https://httpbin.org/status/500');
+            let restRes: restm.IRestResponse<HttpData> = await _rest.get<HttpData>('http://microsoft.com/status/500');
             assert(false, "should throw");
         }
         catch(err) {
@@ -176,91 +287,128 @@ describe('Rest Tests', function () {
     //--------------------------------------------------------
     // Path in baseUrl tests
     //--------------------------------------------------------
-    it('maintains the path from the base url', async() => {
-        this.timeout(3000);
-
-        // Arrange
-        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything');
-
-        // Act
-        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra');
-
-        // Assert
-        assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/anything/anythingextra');
-    });
-
     it('maintains the path from the base url with no slashes', async() => {
+        nock('http://microsoft.com')
+            .get('/anything/anythingextra')
+            .reply(200, {
+                url: 'http://microsoft.com/anything/anythingextra',
+                data: null,
+                json: null
+            });
+
         // Arrange
-        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything');
+        let rest = new restm.RestClient('typed-rest-client-tests', 'http://microsoft.com/anything');
 
         // Act
-        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra');
+        let restRes: restm.IRestResponse<HttpData> = await rest.get<HttpData>('anythingextra');
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/anything/anythingextra');
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com/anything/anythingextra');
     });
 
     it('maintains the path from the base url with double slashes', async() => {
+        nock('http://microsoft.com')
+            .get('/anything/anythingextra')
+            .reply(200, {
+                url: 'http://microsoft.com/anything/anythingextra',
+                data: null,
+                json: null
+            });
+
         // Arrange
-        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything/');
+        let rest = new restm.RestClient('typed-rest-client-tests', 'http://microsoft.com/anything/');
 
         // Act
-        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra');
+        let restRes: restm.IRestResponse<HttpData> = await rest.get<HttpData>('anythingextra');
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/anything/anythingextra');
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com/anything/anythingextra');
     });
 
     it('maintains the path from the base url with multiple parts', async() => {
+        nock('http://microsoft.com')
+            .get('/anything/extrapart/anythingextra')
+            .reply(200, {
+                url: 'http://microsoft.com/anything/extrapart/anythingextra',
+                data: null,
+                json: null
+            });
+        
         // Arrange
-        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything/extrapart');
+        let rest = new restm.RestClient('typed-rest-client-tests', 'http://microsoft.com/anything/extrapart');
 
         // Act
-        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra');
+        let restRes: restm.IRestResponse<HttpData> = await rest.get<HttpData>('anythingextra');
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/anything/extrapart/anythingextra');
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com/anything/extrapart/anythingextra');
     });
 
     it('maintains the path from the base url where request has multiple parts', async() => {
+        nock('http://microsoft.com')
+            .get('/anything/anythingextra/moreparts')
+            .reply(200, {
+                url: 'http://microsoft.com/anything/anythingextra/moreparts',
+                data: null,
+                json: null
+            });
+        
         // Arrange
-        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything');
+        let rest = new restm.RestClient('typed-rest-client-tests', 'http://microsoft.com/anything');
 
         // Act
-        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra/moreparts');
+        let restRes: restm.IRestResponse<HttpData> = await rest.get<HttpData>('anythingextra/moreparts');
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/anything/anythingextra/moreparts');
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com/anything/anythingextra/moreparts');
     });
 
     it('maintains the path from the base url where both have multiple parts', async() => {
+        nock('http://microsoft.com')
+            .get('/anything/multiple/anythingextra/moreparts')
+            .reply(200, {
+                url: 'http://microsoft.com/anything/multiple/anythingextra/moreparts',
+                data: null,
+                json: null
+            });
+        
         // Arrange
-        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything/multiple');
+        let rest = new restm.RestClient('typed-rest-client-tests', 'http://microsoft.com/anything/multiple');
 
         // Act
-        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra/moreparts');
+        let restRes: restm.IRestResponse<HttpData> = await rest.get<HttpData>('anythingextra/moreparts');
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/anything/multiple/anythingextra/moreparts');
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com/anything/multiple/anythingextra/moreparts');
     });
 
     it('maintains the path from the base url where request has query parameters', async() => {
+        nock('http://microsoft.com')
+            .get('/anything/multiple/anythingextra/moreparts')
+            .query({
+                foo: 'bar',
+                baz: 'top'
+            })
+            .reply(200, {
+                url: 'http://microsoft.com/anything/multiple/anythingextra/moreparts?foo=bar&baz=top',
+                data: null,
+                json: null,
+                args: {foo: 'bar', baz: 'top'}
+            });
         // Arrange
-        this.timeout(3000);
-        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything/multiple');
+        let rest = new restm.RestClient('typed-rest-client-tests', 'http://microsoft.com/anything/multiple');
 
         // Act
-        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra/moreparts?foo=bar&baz=top');
+        let restRes: restm.IRestResponse<HttpData> = await rest.get<HttpData>('anythingextra/moreparts?foo=bar&baz=top');
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/anything/multiple/anythingextra/moreparts?foo=bar&baz=top');
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com/anything/multiple/anythingextra/moreparts?foo=bar&baz=top');
         assert(restRes.result && restRes.result.args.foo === 'bar');
         assert(restRes.result && restRes.result.args.baz === 'top');
     });
@@ -269,42 +417,42 @@ describe('Rest Tests', function () {
     // getUrl path tests
     //
     it('resolves a just host resource and no baseUrl', async() => {
-        let res: string = util.getUrl('http://httpbin.org');
-        assert(res === 'http://httpbin.org', "should be http://httpbin.org");
+        let res: string = util.getUrl('http://microsoft.com');
+        assert(res === 'http://microsoft.com', "should be http://microsoft.com");
     });
 
     it('resolves a empty resource with baseUrl', async() => {
-        let res: string = util.getUrl('', 'http://httpbin.org');
-        assert(res === 'http://httpbin.org', "should be http://httpbin.org");
+        let res: string = util.getUrl('', 'http://microsoft.com');
+        assert(res === 'http://microsoft.com', "should be http://microsoft.com");
     });
 
     it('resolves a null resource with baseUrl', async() => {
-        let res: string = util.getUrl(null, 'http://httpbin.org');
-        assert(res === 'http://httpbin.org', "should be http://httpbin.org");
+        let res: string = util.getUrl(null, 'http://microsoft.com');
+        assert(res === 'http://microsoft.com', "should be http://microsoft.com");
     });
 
     it('resolves a full resource and no baseUrl', async() => {
-        let res: string = util.getUrl('http://httpbin.org/get?x=y&a=b');
-        assert(res === 'http://httpbin.org/get?x=y&a=b', `should be http://httpbin.org/get?x=y&a=b but is ${res}`);
+        let res: string = util.getUrl('http://microsoft.com/get?x=y&a=b');
+        assert(res === 'http://microsoft.com/get?x=y&a=b', `should be http://microsoft.com/get?x=y&a=b but is ${res}`);
     });
 
     it('resolves a rooted path resource with host baseUrl', async() => {
-        let res: string = util.getUrl('/get/foo', 'http://httpbin.org');
-        assert(res === 'http://httpbin.org/get/foo', `should be http://httpbin.org/get/foo but is ${res}`);
+        let res: string = util.getUrl('/get/foo', 'http://microsoft.com');
+        assert(res === 'http://microsoft.com/get/foo', `should be http://microsoft.com/get/foo but is ${res}`);
     });
 
     it('resolves a relative path resource with host baseUrl', async() => {
-        let res: string = util.getUrl('get/foo', 'http://httpbin.org');
-        assert(res === 'http://httpbin.org/get/foo', `should be http://httpbin.org/get/foo but is ${res}`);
+        let res: string = util.getUrl('get/foo', 'http://microsoft.com');
+        assert(res === 'http://microsoft.com/get/foo', `should be http://microsoft.com/get/foo but is ${res}`);
     });
 
     it('resolves a rooted path resource with pathed baseUrl', async() => {
-        let res: string = util.getUrl('/get/foo', 'http://httpbin.org/bar');
-        assert(res === 'http://httpbin.org/get/foo', "should be http://httpbin.org/get/foo");
+        let res: string = util.getUrl('/get/foo', 'http://microsoft.com/bar');
+        assert(res === 'http://microsoft.com/get/foo', "should be http://microsoft.com/get/foo");
     });
 
     it('resolves a relative path resource with pathed baseUrl', async() => {
-        let res: string = util.getUrl('get/foo', 'http://httpbin.org/bar');
-        assert(res === 'http://httpbin.org/bar/get/foo', `should be http://httpbin.org/bar/get/foo but is ${res}`);
+        let res: string = util.getUrl('get/foo', 'http://microsoft.com/bar');
+        assert(res === 'http://microsoft.com/bar/get/foo', `should be http://microsoft.com/bar/get/foo but is ${res}`);
     });
 });

--- a/test/resttests.ts
+++ b/test/resttests.ts
@@ -254,14 +254,14 @@ describe('Rest Tests', function () {
     it('gets and handles unauthorized (401)', async() => {
         nock('http://microsoft.com')
             .get('/status/401')
-            .replyWithError({'message': 'something awful happened', 'statusCode': 401});
+            .reply(401, {'message': 'something awful happened', 'statusCode': 401});
         try {
             let restRes: restm.IRestResponse<HttpData> = await _rest.get<HttpData>('http://microsoft.com/status/401');
             assert(false, "should throw");
         }
         catch(err) {
             assert(err['statusCode'] == 401, "statusCode should be 401");
-            assert(err.message && err.message.length > 0, "should have error message");
+            assert(err.result && err.result['message'] === 'something awful happened', "should have error message with the response");
         }
     });
 
@@ -273,14 +273,14 @@ describe('Rest Tests', function () {
     it('gets and handles a server error (500)', async() => {
         nock('http://microsoft.com')
             .get('/status/500')
-            .replyWithError({'message': 'something awful happened', 'statusCode': 500});
+            .reply(500, {'message': 'something awful happened', 'statusCode': 500});
         try {
             let restRes: restm.IRestResponse<HttpData> = await _rest.get<HttpData>('http://microsoft.com/status/500');
             assert(false, "should throw");
         }
         catch(err) {
             assert(err['statusCode'] == 500, "statusCode should be 500");
-            assert(err.message && err.message.length > 0, "should have error message");
+            assert(err.result && err.result['message'] === 'something awful happened', "should have error message with the response");
         }
     });
 

--- a/test/tests/httptests.ts
+++ b/test/tests/httptests.ts
@@ -1,0 +1,226 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import assert = require('assert');
+import * as httpm from 'typed-rest-client/HttpClient';
+import * as hm from 'typed-rest-client/Handlers';
+import * as fs from 'fs';
+import * as path from 'path';
+
+let sampleFilePath: string = path.join(__dirname, 'testoutput.txt');
+
+describe('Http Tests', function () {
+    let _http: httpm.HttpClient;
+    let _httpbin: httpm.HttpClient;
+
+    before(() => {
+        _http = new httpm.HttpClient('typed-test-client-tests');
+    });
+
+    after(() => {
+    });
+
+    it('constructs', () => {
+        this.timeout(1000);
+
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests');
+        assert(http, 'http client should not be null');
+    });
+
+    // responses from httpbin return something like:
+    // {
+    //     "args": {}, 
+    //     "headers": {
+    //       "Connection": "close", 
+    //       "Host": "httpbin.org", 
+    //       "User-Agent": "typed-test-client-tests"
+    //     }, 
+    //     "origin": "173.95.152.44", 
+    //     "url": "https://httpbin.org/get"
+    //  }  
+    it('does basic http get request', async() => {
+        let res: httpm.HttpClientResponse = await _http.get('http://httpbin.org/get');
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();      
+        let obj:any = JSON.parse(body);
+        assert(obj.url === "http://httpbin.org/get");
+    });
+
+    it('does basic https get request', async() => {
+        let res: httpm.HttpClientResponse = await _http.get('https://httpbin.org/get');
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();
+        let obj:any = JSON.parse(body);
+        assert(obj.url === "https://httpbin.org/get");
+    });
+
+    it('does basic http get request with basic auth', async() => {
+        let bh: hm.BasicCredentialHandler = new hm.BasicCredentialHandler('johndoe', 'password');
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-rest-client-tests', [bh]);
+        let res: httpm.HttpClientResponse = await http.get('http://httpbin.org/get');
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody(); 
+        let obj:any = JSON.parse(body);
+        let auth: string = obj.headers.Authorization;
+        let creds: string = Buffer.from(auth.substring('Basic '.length), 'base64').toString();
+        assert(creds === 'johndoe:password', "should be the username and password");
+        assert(obj.url === "http://httpbin.org/get");
+    });
+    
+    it('does basic http get request with pat token auth', async() => {
+        let token: string = 'scbfb44vxzku5l4xgc3qfazn3lpk4awflfryc76esaiq7aypcbhs';
+        let ph: hm.PersonalAccessTokenCredentialHandler = 
+            new hm.PersonalAccessTokenCredentialHandler(token);
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-rest-client-tests', [ph]);
+        let res: httpm.HttpClientResponse = await http.get('http://httpbin.org/get');
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody(); 
+        let obj:any = JSON.parse(body);
+        let auth: string = obj.headers.Authorization;
+        let creds: string = Buffer.from(auth.substring('Basic '.length), 'base64').toString();
+        assert(creds === 'PAT:' + token, "creds should be the token");
+        assert(obj.url === "http://httpbin.org/get");
+    });
+
+    it('pipes a get request', () => {
+        return new Promise<string>(async (resolve, reject) => {
+            let file: NodeJS.WritableStream = fs.createWriteStream(sampleFilePath);
+            (await _http.get('https://httpbin.org/get')).message.pipe(file).on('close', () => {
+                let body: string = fs.readFileSync(sampleFilePath).toString();
+                let obj:any = JSON.parse(body);
+                assert(obj.url === "https://httpbin.org/get", "response from piped stream should have url");
+                resolve();
+            });
+        });
+    });
+    
+    it('does basic get request with redirects', async() => {
+        let res: httpm.HttpClientResponse = await _http.get("https://httpbin.org/redirect-to?url=" + encodeURIComponent("https://httpbin.org/get"))
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();
+        let obj:any = JSON.parse(body);
+        assert(obj.url === "https://httpbin.org/get");
+    });
+
+    it('does basic get request with redirects (303)', async() => {
+        let res: httpm.HttpClientResponse = await _http.get("https://httpbin.org/redirect-to?url=" + encodeURIComponent("https://httpbin.org/get") + '&status_code=303')
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();
+        let obj:any = JSON.parse(body);
+        assert(obj.url === "https://httpbin.org/get");
+    });
+
+    it('returns 404 for not found get request on redirect', async() => {
+        let res: httpm.HttpClientResponse = await _http.get("https://httpbin.org/redirect-to?url=" + encodeURIComponent("http://httpbin.org/status/404") + '&status_code=303')
+        assert(res.message.statusCode == 404, "status code should be 404");
+        let body: string = await res.readBody();
+    });
+
+    it('does not follow redirects if disabled', async() => {
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests', null, { allowRedirects: false });
+        let res: httpm.HttpClientResponse = await http.get("https://httpbin.org/redirect-to?url=" + encodeURIComponent("https://httpbin.org/get"))
+        assert(res.message.statusCode == 302, "status code should be 302");
+        let body: string = await res.readBody();
+    });
+
+    it('does basic head request', async() => {
+        let res: httpm.HttpClientResponse = await _http.head('http://httpbin.org/get');
+        assert(res.message.statusCode == 200, "status code should be 200");
+    });
+
+    it('does basic http delete request', async() => {
+        let res: httpm.HttpClientResponse = await _http.del('http://httpbin.org/delete');
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();      
+        let obj:any = JSON.parse(body);
+    });
+
+    it('does basic http post request', async() => {
+        let b: string = 'Hello World!';
+        let res: httpm.HttpClientResponse = await _http.post('http://httpbin.org/post', b);
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();
+        let obj:any = JSON.parse(body);
+        assert(obj.data === b);
+        assert(obj.url === "http://httpbin.org/post");
+    });
+    
+    it('does basic http patch request', async() => {
+        let b: string = 'Hello World!';
+        let res: httpm.HttpClientResponse = await _http.patch('http://httpbin.org/patch', b);
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();
+        let obj:any = JSON.parse(body);
+        assert(obj.data === b);
+        assert(obj.url === "http://httpbin.org/patch");
+    });
+    
+    it('does basic http options request', async() => {
+        let res: httpm.HttpClientResponse = await _http.options('http://httpbin.org');
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();
+    });
+    
+    it('returns 404 for not found get request', async() => {
+        let res: httpm.HttpClientResponse = await _http.get('http://httpbin.org/status/404');
+        assert(res.message.statusCode == 404, "status code should be 404");
+        let body: string = await res.readBody();
+    });
+});
+
+describe('Http Tests with keepAlive', function () {
+    let _http: httpm.HttpClient;
+
+    before(() => {
+        _http = new httpm.HttpClient('typed-test-client-tests', [], { keepAlive: true });
+    });
+
+    after(() => {
+    });
+
+    it('does basic http get request with keepAlive true', async() => {
+        let res: httpm.HttpClientResponse = await _http.get('http://httpbin.org/get');
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();      
+        let obj:any = JSON.parse(body);
+        assert(obj.url === "http://httpbin.org/get");
+    });
+
+    it('does basic head request with keepAlive true', async() => {
+        let res: httpm.HttpClientResponse = await _http.head('http://httpbin.org/get');
+        assert(res.message.statusCode == 200, "status code should be 200");
+    });    
+
+    it('does basic http delete request with keepAlive true', async() => {
+        let res: httpm.HttpClientResponse = await _http.del('http://httpbin.org/delete');
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();      
+        let obj:any = JSON.parse(body);
+    });
+
+    it('does basic http post request with keepAlive true', async() => {
+        let b: string = 'Hello World!';
+        let res: httpm.HttpClientResponse = await _http.post('http://httpbin.org/post', b);
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();
+        let obj:any = JSON.parse(body);
+        assert(obj.data === b);
+        assert(obj.url === "http://httpbin.org/post");
+    });
+    
+    it('does basic http patch request with keepAlive true', async() => {
+        let b: string = 'Hello World!';
+        let res: httpm.HttpClientResponse = await _http.patch('http://httpbin.org/patch', b);
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();
+        let obj:any = JSON.parse(body);
+        assert(obj.data === b);
+        assert(obj.url === "http://httpbin.org/patch");
+    }); 
+    
+    it('does basic http options request with keepAlive true', async() => {
+        let res: httpm.HttpClientResponse = await _http.options('http://httpbin.org');
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();
+    });
+});

--- a/test/tests/resttests.ts
+++ b/test/tests/resttests.ts
@@ -1,0 +1,267 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import assert = require('assert');
+import * as restm from 'typed-rest-client/RestClient';
+import * as util from 'typed-rest-client/Util';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface HttpBinData {
+    url: string;
+    data: any;
+    json: any;
+    args?: any
+}
+
+describe('Rest Tests', function () {
+    let _rest: restm.RestClient;
+    let _restBin: restm.RestClient;
+
+    before(() => {
+        _rest = new restm.RestClient('typed-rest-client-tests');
+        _restBin = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org');
+    });
+
+    after(() => {
+    });
+
+    it('constructs', () => {
+        this.timeout(1000);
+
+        let rest: restm.RestClient = new restm.RestClient('typed-test-client-tests');
+        assert(rest, 'rest client should not be null');
+    })
+
+    it('gets a resource', async() => {
+        this.timeout(3000);
+
+        let restRes: restm.IRestResponse<HttpBinData> = await _rest.get<HttpBinData>('https://httpbin.org/get');
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/get');
+    });
+
+    it('gets a resource with baseUrl', async() => {
+        let restRes: restm.IRestResponse<HttpBinData> = await _restBin.get<HttpBinData>('get');
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/get');
+    });
+
+    it('creates a resource', async() => {
+        let res: any = { name: 'foo' };
+        let restRes: restm.IRestResponse<HttpBinData> = await _rest.create<HttpBinData>('https://httpbin.org/post', res);
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/post');
+        assert(restRes.result && restRes.result.json.name === 'foo');
+    });
+
+    it('creates a resource with a baseUrl', async() => {
+        let res: any = { name: 'foo' };
+        let restRes: restm.IRestResponse<HttpBinData> = await _restBin.create<HttpBinData>('post', res);
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/post');
+        assert(restRes.result && restRes.result.json.name === 'foo');
+    });
+
+    it('replaces a resource', async() => {
+        this.timeout(3000);
+
+        let res: any = { name: 'foo' };
+        let restRes: restm.IRestResponse<HttpBinData> = await _rest.replace<HttpBinData>('https://httpbin.org/put', res);
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/put');
+        assert(restRes.result && restRes.result.json.name === 'foo');
+    });
+
+    it('replaces a resource with a baseUrl', async() => {
+        let res: any = { name: 'foo' };
+        let restRes: restm.IRestResponse<HttpBinData> = await _restBin.replace<HttpBinData>('put', res);
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/put');
+        assert(restRes.result && restRes.result.json.name === 'foo');
+    });
+
+    it('updates a resource', async() => {
+        let res: any = { name: 'foo' };
+        let restRes: restm.IRestResponse<HttpBinData> = await _rest.update<HttpBinData>('https://httpbin.org/patch', res);
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/patch');
+        assert(restRes.result && restRes.result.json.name === 'foo');
+    });
+
+    it('updates a resource with a baseUrl', async() => {
+        let res: any = { name: 'foo' };
+        let restRes: restm.IRestResponse<HttpBinData> = await _restBin.update<HttpBinData>('patch', res);
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/patch');
+        assert(restRes.result && restRes.result.json.name === 'foo');
+    });
+
+    it('deletes a resource', async() => {
+        let restRes: restm.IRestResponse<HttpBinData> = await _rest.del<HttpBinData>('https://httpbin.org/delete');
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/delete');
+    });
+
+    it('deletes a resource with a baseUrl', async() => {
+        let restRes: restm.IRestResponse<HttpBinData> = await _restBin.del<HttpBinData>('delete');
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/delete');
+    });
+
+    it('does an options request', async() => {
+        let restRes: restm.IRestResponse<HttpBinData> = await _rest.options<HttpBinData>('https://httpbin.org');
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+    });
+
+    it('does an options request with baseUrl', async() => {
+        let restRes: restm.IRestResponse<HttpBinData> = await _restBin.options<HttpBinData>('');
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+    });
+
+    //----------------------------------------------
+    // Get Error Cases
+    //----------------------------------------------
+
+    //
+    // Resource not found (404)
+    // should return a null resource, 404 status, and should not throw
+    //
+    it('gets a non-existant resource (404)', async() => {
+        this.timeout(3000);
+
+        try {
+            let restRes: restm.IRestResponse<HttpBinData> = await _rest.get<HttpBinData>('https://httpbin.org/status/404');
+
+            assert(restRes.statusCode == 404, "statusCode should be 404");
+            assert(restRes.result === null, "object should be null");
+        }
+        catch(err) {
+            assert(false, "should not throw");
+        }
+    });
+
+    //
+    // Unauthorized (401)
+    // should throw and attach statusCode to the Error object
+    // err.message is message proerty of resourceful error object or if not supplied, a generic error message
+    //
+    it('gets and handles unauthorized (401)', async() => {
+        try {
+            let restRes: restm.IRestResponse<HttpBinData> = await _rest.get<HttpBinData>('https://httpbin.org/status/401');
+            assert(false, "should throw");
+        }
+        catch(err) {
+            assert(err['statusCode'] == 401, "statusCode should be 401");
+            assert(err.message && err.message.length > 0, "should have error message");
+        }
+    });
+
+    //
+    // Internal Server Error
+    // should throw and attach statusCode to the Error object
+    // err.message is message proerty of resourceful error object or if not supplied, a generic error message
+    //
+    it('gets and handles a server error (500)', async() => {
+        try {
+            let restRes: restm.IRestResponse<HttpBinData> = await _rest.get<HttpBinData>('https://httpbin.org/status/500');
+            assert(false, "should throw");
+        }
+        catch(err) {
+            assert(err['statusCode'] == 500, "statusCode should be 500");
+            assert(err.message && err.message.length > 0, "should have error message");
+        }
+    });
+
+    //--------------------------------------------------------
+    // Path in baseUrl tests
+    //--------------------------------------------------------
+    it('maintains the path from the base url', async() => {
+        this.timeout(3000);
+
+        // Arrange
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything');
+
+        // Act
+        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra');
+
+        // Assert
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/anything/anythingextra');
+    });
+
+    it('maintains the path from the base url with no slashes', async() => {
+        // Arrange
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything');
+
+        // Act
+        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra');
+
+        // Assert
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/anything/anythingextra');
+    });
+
+    it('maintains the path from the base url with double slashes', async() => {
+        // Arrange
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything/');
+
+        // Act
+        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra');
+
+        // Assert
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/anything/anythingextra');
+    });
+
+    it('maintains the path from the base url with multiple parts', async() => {
+        // Arrange
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything/extrapart');
+
+        // Act
+        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra');
+
+        // Assert
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/anything/extrapart/anythingextra');
+    });
+
+    it('maintains the path from the base url where request has multiple parts', async() => {
+        // Arrange
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything');
+
+        // Act
+        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra/moreparts');
+
+        // Assert
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/anything/anythingextra/moreparts');
+    });
+
+    it('maintains the path from the base url where both have multiple parts', async() => {
+        // Arrange
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything/multiple');
+
+        // Act
+        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra/moreparts');
+
+        // Assert
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/anything/multiple/anythingextra/moreparts');
+    });
+
+    it('maintains the path from the base url where request has query parameters', async() => {
+        // Arrange
+        this.timeout(3000);
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything/multiple');
+
+        // Act
+        let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra/moreparts?foo=bar&baz=top');
+
+        // Assert
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'https://httpbin.org/anything/multiple/anythingextra/moreparts?foo=bar&baz=top');
+        assert(restRes.result && restRes.result.args.foo === 'bar');
+        assert(restRes.result && restRes.result.args.baz === 'top');
+    });
+});

--- a/test/tests/tsconfig.json
+++ b/test/tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": false,
+        "sourceMap": false
+    }
+}

--- a/test/units/httptests.ts
+++ b/test/units/httptests.ts
@@ -1,0 +1,340 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import assert = require('assert');
+import nock = require('nock');
+import * as httpm from 'typed-rest-client/HttpClient';
+import * as hm from 'typed-rest-client/Handlers';
+import * as fs from 'fs';
+import * as path from 'path';
+
+let sampleFilePath: string = path.join(__dirname, 'testoutput.txt');
+
+describe('Http Tests', function () {
+    let _http: httpm.HttpClient;
+
+    before(() => {
+        _http = new httpm.HttpClient('typed-test-client-tests');
+    });
+
+    after(() => {
+    });
+
+    afterEach(() => {
+        nock.cleanAll();
+    })
+
+    it('constructs', () => {
+        this.timeout(1000);
+
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests');
+        assert(http, 'http client should not be null');
+    });
+
+    it('does basic http get request', async() => {
+        nock('http://microsoft.com')
+            .get('/')
+            .reply(200, {
+                source: "nock"
+            });
+        let res: httpm.HttpClientResponse = await _http.get('http://microsoft.com');
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();      
+        let obj: any = JSON.parse(body);
+        assert(obj.source === "nock", "http get request should be intercepted by nock");
+    })
+
+    it('does basic http get request with basic auth', async() => {
+        //Set nock for correct credentials
+        nock('http://microsoft.com')
+            .get('/')
+            .basicAuth({
+                user: 'johndoe',
+                pass: 'password'
+            })
+            .reply(200, {
+                success: true,
+                source: "nock"
+            });
+        //Set nock for request without credentials or with incorrect credentials
+        nock('http://microsoft.com')
+            .get('/')
+            .reply(200, {
+                success: false,
+                source: "nock"
+            });
+        let bh: hm.BasicCredentialHandler = new hm.BasicCredentialHandler('johndoe', 'password');
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-rest-client-tests', [bh]);
+        let res: httpm.HttpClientResponse = await http.get('http://microsoft.com');
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();      
+        let obj: any = JSON.parse(body);
+        assert(obj.source === "nock", "http get request should be intercepted by nock");
+        assert(obj.success, "Authentication should succeed");
+    });
+    
+    it('does basic http get request with pat token auth', async() => {
+        let token: string = 'scbfb44vxzku5l4xgc3qfazn3lpk4awflfryc76esaiq7aypcbhs';
+        let pat: string = new Buffer('PAT:' + token).toString('base64')
+        //Set nock for correct credentials
+        nock('http://microsoft.com', {
+            reqheaders: {
+                'Authorization': 'Basic ' + pat,
+                'X-TFS-FedAuthRedirect': 'Suppress'
+            }})
+            .get('/')
+            .reply(200, {
+                success: true,
+                source: "nock"
+            });
+        //Set nock for request without credentials or with incorrect credentials
+        nock('http://microsoft.com')
+            .get('/')
+            .reply(200, {
+                success: false,
+                source: "nock"
+            });
+        let ph: hm.PersonalAccessTokenCredentialHandler = 
+            new hm.PersonalAccessTokenCredentialHandler(token);
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-rest-client-tests', [ph]);
+        let res: httpm.HttpClientResponse = await http.get('http://microsoft.com');
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();      
+        let obj: any = JSON.parse(body);
+        assert(obj.source === "nock", "http get request should be intercepted by nock");
+        assert(obj.success, "Authentication should succeed");
+    });
+
+    it('pipes a get request', () => {
+        nock('http://microsoft.com')
+            .get('/')
+            .reply(200, {
+                url: "http://microsoft.com"
+            });
+        return new Promise<string>(async (resolve, reject) => {
+            let file: NodeJS.WritableStream = fs.createWriteStream(sampleFilePath);
+            (await _http.get('http://microsoft.com')).message.pipe(file).on('close', () => {
+                let body: string = fs.readFileSync(sampleFilePath).toString();
+                let obj:any = JSON.parse(body);
+                assert(obj.url === "http://microsoft.com", "response from piped stream should have url");
+                resolve();
+            });
+        });
+    });
+    
+    it('does basic get request with redirects', async() => {
+        nock('http://microsoft.com')
+            .get('/redirect-to')
+            .reply(301, undefined, {
+                location:'http://microsoft.com'
+            });
+        nock('http://microsoft.com')
+            .get('/')
+            .reply(200, {
+                source: "nock"
+            });
+        let res: httpm.HttpClientResponse = await _http.get('http://microsoft.com/redirect-to');
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();      
+        let obj: any = JSON.parse(body);
+        assert(obj.source === "nock", "request should redirect to mocked page");
+    });
+
+    it('does basic get request with redirects (303)', async() => {
+        nock('http://microsoft.com')
+            .get('/redirect-to')
+            .reply(303, undefined, {
+                location:'http://microsoft.com'
+            });
+        nock('http://microsoft.com')
+            .get('/')
+            .reply(200, {
+                source: "nock"
+            });
+        let res: httpm.HttpClientResponse = await _http.get('http://microsoft.com/redirect-to');
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();      
+        let obj: any = JSON.parse(body);
+        assert(obj.source === "nock", "request should redirect to mocked page");
+    });
+
+    it('returns 404 for not found get request on redirect', async() => {
+        nock('http://microsoft.com')
+        .get('/redirect-to')
+        .reply(301, undefined, {
+            location:'http://badmicrosoft.com'
+        });
+        nock('http://badmicrosoft.com')
+        .get('/')
+        .reply(404, {
+            source: "nock"
+        });
+    let res: httpm.HttpClientResponse = await _http.get('http://microsoft.com/redirect-to');
+    assert(res.message.statusCode == 404, "status code should be 404");
+    let body: string = await res.readBody();      
+    let obj: any = JSON.parse(body);
+    assert(obj.source === "nock", "request should redirect to mocked missing");
+    });
+
+    it('does not follow redirects if disabled', async() => {
+        nock('http://microsoft.com')
+        .get('/redirect-to')
+        .reply(302, undefined, {
+            location:'http://microsoft.com'
+        });
+        nock('http://microsoft.com')
+            .get('/')
+            .reply(200, {
+                source: "nock"
+            });
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests', null, { allowRedirects: false });
+        let res: httpm.HttpClientResponse = await http.get('http://microsoft.com/redirect-to');
+        assert(res.message.statusCode == 302, "status code should be 302");
+        let body: string = await res.readBody();
+    });
+
+    it('does basic head request', async() => {
+        nock('http://microsoft.com')
+            .head('/')
+            .reply(200, {
+                source: "nock"
+            });
+        let res: httpm.HttpClientResponse = await _http.head('http://microsoft.com');
+        assert(res.message.statusCode == 200, "status code should be 200");
+    });
+
+    it('does basic http delete request', async() => {
+        nock('http://microsoft.com')
+            .delete('/')
+            .reply(200, {
+                source: "nock"
+            });
+        let res: httpm.HttpClientResponse = await _http.del('http://microsoft.com');
+        assert(res.message.statusCode == 200, "status code should be 200");
+    });
+
+    it('does basic http post request', async() => {
+        nock('http://microsoft.com')
+            .post('/')
+            .reply(200, function(uri, requestBody) {
+                return {data: requestBody};
+            });
+        let b: string = 'Hello World!';
+        let res: httpm.HttpClientResponse = await _http.post('http://microsoft.com', b);
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();
+        let obj:any = JSON.parse(body);
+        assert(obj.data === b);
+    });
+    
+    it('does basic http patch request', async() => {
+        nock('http://microsoft.com')
+            .patch('/')
+            .reply(200, function(uri, requestBody) {
+                return {data: requestBody};
+            });
+        let b: string = 'Hello World!';
+        let res: httpm.HttpClientResponse = await _http.patch('http://microsoft.com', b);
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();
+        let obj:any = JSON.parse(body);
+        assert(obj.data === b);
+    });
+    
+    it('does basic http options request', async() => {
+        nock('http://microsoft.com')
+            .options('/')
+            .reply(200);
+        let res: httpm.HttpClientResponse = await _http.options('http://microsoft.com');
+        assert(res.message.statusCode == 200, "status code should be 200");
+    });
+    
+    it('returns 404 for not found get request', async() => {
+        nock('http://badmicrosoft.com')
+            .get('/')
+            .reply(404);
+        let res: httpm.HttpClientResponse = await _http.get('http://badmicrosoft.com');
+        assert(res.message.statusCode == 404, "status code should be 404");
+        let body: string = await res.readBody();
+    });
+});
+
+describe('Http Tests with keepAlive', function () {
+    let _http: httpm.HttpClient;
+
+    before(() => {
+        _http = new httpm.HttpClient('typed-test-client-tests', [], { keepAlive: true });
+    });
+
+    after(() => {
+    });
+
+    it('does basic http get request with keepAlive true', async() => {
+        nock('http://microsoft.com')
+            .get('/')
+            .reply(200, {
+                source: "nock"
+            });
+        let res: httpm.HttpClientResponse = await _http.get('http://microsoft.com');
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();      
+        let obj: any = JSON.parse(body);
+        assert(obj.source === "nock", "http get request should be intercepted by nock");
+    });
+
+    it('does basic head request with keepAlive true', async() => {
+        nock('http://microsoft.com')
+            .head('/')
+            .reply(200, {
+                source: "nock"
+            });
+        let res: httpm.HttpClientResponse = await _http.head('http://microsoft.com');
+        assert(res.message.statusCode == 200, "status code should be 200");
+    });    
+
+    it('does basic http delete request with keepAlive true', async() => {
+        nock('http://microsoft.com')
+            .delete('/')
+            .reply(200, {
+                source: "nock"
+            });
+        let res: httpm.HttpClientResponse = await _http.del('http://microsoft.com');
+        assert(res.message.statusCode == 200, "status code should be 200");
+    });
+
+    it('does basic http post request with keepAlive true', async() => {
+        nock('http://microsoft.com')
+            .post('/')
+            .reply(200, function(uri, requestBody) {
+                return {data: requestBody};
+            });
+        let b: string = 'Hello World!';
+        let res: httpm.HttpClientResponse = await _http.post('http://microsoft.com', b);
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();
+        let obj:any = JSON.parse(body);
+        assert(obj.data === b);
+    });
+    
+    it('does basic http patch request with keepAlive true', async() => {
+        nock('http://microsoft.com')
+            .patch('/')
+            .reply(200, function(uri, requestBody) {
+                return {data: requestBody};
+            });
+        let b: string = 'Hello World!';
+        let res: httpm.HttpClientResponse = await _http.patch('http://microsoft.com', b);
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();
+        let obj:any = JSON.parse(body);
+        assert(obj.data === b);
+    }); 
+    
+    it('does basic http options request with keepAlive true', async() => {
+        nock('http://microsoft.com')
+            .options('/')
+            .reply(200);
+        let res: httpm.HttpClientResponse = await _http.options('http://microsoft.com');
+        assert(res.message.statusCode == 200, "status code should be 200");
+    });
+});

--- a/test/units/resttests.ts
+++ b/test/units/resttests.ts
@@ -1,0 +1,458 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import assert = require('assert');
+import nock = require('nock');
+import * as restm from 'typed-rest-client/RestClient';
+import * as util from 'typed-rest-client/Util';
+
+export interface HttpData {
+    url: string;
+    data: any;
+    json: any;
+    args?: any
+}
+
+describe('Rest Tests', function () {
+    let _rest: restm.RestClient;
+    let _restBin: restm.RestClient;
+    let _restMic: restm.RestClient;
+
+    before(() => {
+        _rest = new restm.RestClient('typed-rest-client-tests');
+        _restBin = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org');
+        _restMic = new restm.RestClient('typed-rest-client-tests', 'http://microsoft.com');
+    });
+
+    after(() => {
+    });
+
+    afterEach(() => {
+        nock.cleanAll();
+    })
+
+    it('constructs', () => {
+        this.timeout(1000);
+
+        let rest: restm.RestClient = new restm.RestClient('typed-test-client-tests');
+        assert(rest, 'rest client should not be null');
+    })
+
+    it('gets a resource', async() => {
+        nock('http://microsoft.com')
+            .get('/')
+            .reply(200, {
+                url: 'http://microsoft.com',
+                data: null,
+                json: null
+            });
+        let restRes: restm.IRestResponse<HttpData> = await _rest.get<HttpData>('http://microsoft.com');
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com');
+    });
+
+    it('gets a resource with baseUrl', async() => {
+        nock('http://microsoft.com')
+            .get('/')
+            .reply(200, {
+                url: 'http://microsoft.com',
+                data: null,
+                json: null
+            });
+        let restRes: restm.IRestResponse<HttpData> = await _restMic.get<HttpData>('');
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com');
+    });
+
+    it('creates a resource', async() => {
+        nock('http://microsoft.com')
+            .post('/')
+            .reply(200, function(uri, requestBody) {
+                let body = JSON.parse(requestBody);
+                return {
+                    url: 'http://microsoft.com/post',
+                    data: null,
+                    json: body.name
+                };
+            });
+        let res: any = { name: 'foo' };
+        let restRes: restm.IRestResponse<HttpData> = await _rest.create<HttpData>('http://microsoft.com', res);
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com/post');
+        assert(restRes.result && restRes.result.json === 'foo');
+    });
+
+    it('creates a resource with a baseUrl', async() => {
+        nock('http://microsoft.com')
+            .post('/')
+            .reply(200, function(uri, requestBody) {
+                let body = JSON.parse(requestBody);
+                return {
+                    url: 'http://microsoft.com/post',
+                    data: null,
+                    json: body.name
+                };
+            });
+        let res: any = { name: 'foo' };
+        let restRes: restm.IRestResponse<HttpData> = await _restMic.create<HttpData>('', res);
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com/post');
+        assert(restRes.result && restRes.result.json === 'foo');
+    });
+
+    it('replaces a resource', async() => {
+        nock('http://microsoft.com')
+            .put('/')
+            .reply(200, function(uri, requestBody) {
+                let body = JSON.parse(requestBody);
+                return {
+                    url: 'http://microsoft.com/put',
+                    data: null,
+                    json: body.name
+                };
+            });
+        let res: any = { name: 'foo' };
+        let restRes: restm.IRestResponse<HttpData> = await _rest.replace<HttpData>('http://microsoft.com', res);
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com/put');
+        assert(restRes.result && restRes.result.json === 'foo');
+    });
+
+    it('replaces a resource with a baseUrl', async() => {
+        nock('http://microsoft.com')
+            .put('/')
+            .reply(200, function(uri, requestBody) {
+                let body = JSON.parse(requestBody);
+                return {
+                    url: 'http://microsoft.com/put',
+                    data: null,
+                    json: body.name
+                };
+            });
+        let res: any = { name: 'foo' };
+        let restRes: restm.IRestResponse<HttpData> = await _restMic.replace<HttpData>('', res);
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com/put');
+        assert(restRes.result && restRes.result.json === 'foo');
+    });
+
+    it('updates a resource', async() => {
+        nock('http://microsoft.com')
+            .put('/')
+            .reply(200, function(uri, requestBody) {
+                let body = JSON.parse(requestBody);
+                return {
+                    url: 'http://microsoft.com/put',
+                    data: null,
+                    json: body.name
+                };
+            });
+        let res: any = { name: 'foo' };
+        let restRes: restm.IRestResponse<HttpData> = await _rest.replace<HttpData>('http://microsoft.com', res);
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com/put');
+        assert(restRes.result && restRes.result.json === 'foo');
+    });
+
+    it('updates a resource with a baseUrl', async() => {
+        nock('http://microsoft.com')
+            .put('/')
+            .reply(200, function(uri, requestBody) {
+                let body = JSON.parse(requestBody);
+                return {
+                    url: 'http://microsoft.com/put',
+                    data: null,
+                    json: body.name
+                };
+            });
+        let res: any = { name: 'foo' };
+        let restRes: restm.IRestResponse<HttpData> = await _restMic.replace<HttpData>('', res);
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com/put');
+        assert(restRes.result && restRes.result.json === 'foo');
+    });
+
+    it('deletes a resource', async() => {
+        nock('http://microsoft.com')
+            .delete('/')
+            .reply(200, {
+                url: 'http://microsoft.com/delete',
+                data: null,
+                json: null
+            });
+        let restRes: restm.IRestResponse<HttpData> = await _rest.del<HttpData>('http://microsoft.com');
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com/delete');
+    });
+
+    it('deletes a resource with a baseUrl', async() => {
+        nock('http://microsoft.com')
+            .delete('/')
+            .reply(200, {
+                url: 'http://microsoft.com/delete',
+                data: null,
+                json: null
+            });
+        let restRes: restm.IRestResponse<HttpData> = await _restMic.del<HttpData>('');
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com/delete');
+    });
+
+    it('does an options request', async() => {
+        nock('http://microsoft.com')
+            .options('/')
+            .reply(200, {
+                url: 'http://microsoft.com/options',
+                data: null,
+                json: null
+            });
+        let restRes: restm.IRestResponse<HttpData> = await _rest.options<HttpData>('http://microsoft.com');
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+    });
+
+    it('does an options request with baseUrl', async() => {
+        nock('http://microsoft.com')
+            .options('/')
+            .reply(200, {
+                url: 'http://microsoft.com/options',
+                data: null,
+                json: null
+            });
+        let restRes: restm.IRestResponse<HttpData> = await _restMic.options<HttpData>('');
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+    });
+
+    //----------------------------------------------
+    // Get Error Cases
+    //----------------------------------------------
+
+    //
+    // Resource not found (404)
+    // should return a null resource, 404 status, and should not throw
+    //
+    it('gets a non-existant resource (404)', async() => {
+        nock('http://microsoft.com')
+            .get('/status/404')
+            .reply(404);
+        let restRes: restm.IRestResponse<HttpData>;
+        try {
+            restRes= await _rest.get<HttpData>('http://microsoft.com/status/404');
+        }
+        catch(err) {
+            console.log(err);
+            assert(false, "Request should succeed, should not throw");
+        }
+        assert(restRes.statusCode == 404, "statusCode should be 404");
+        assert(restRes.result === null, "object should be null");
+    });
+
+    //
+    // Unauthorized (401)
+    // should throw and attach statusCode to the Error object
+    // err.message is message proerty of resourceful error object or if not supplied, a generic error message
+    //
+    it('gets and handles unauthorized (401)', async() => {
+        nock('http://microsoft.com')
+            .get('/status/401')
+            .reply(401, {'message': 'something awful happened', 'statusCode': 401});
+        try {
+            let restRes: restm.IRestResponse<HttpData> = await _rest.get<HttpData>('http://microsoft.com/status/401');
+            assert(false, "should throw");
+        }
+        catch(err) {
+            assert(err['statusCode'] == 401, "statusCode should be 401");
+            assert(err.result && err.result['message'] === 'something awful happened', "should have error message with the response");
+        }
+    });
+
+    //
+    // Internal Server Error
+    // should throw and attach statusCode to the Error object
+    // err.message is message proerty of resourceful error object or if not supplied, a generic error message
+    //
+    it('gets and handles a server error (500)', async() => {
+        nock('http://microsoft.com')
+            .get('/status/500')
+            .reply(500, {'message': 'something awful happened', 'statusCode': 500});
+        try {
+            let restRes: restm.IRestResponse<HttpData> = await _rest.get<HttpData>('http://microsoft.com/status/500');
+            assert(false, "should throw");
+        }
+        catch(err) {
+            assert(err['statusCode'] == 500, "statusCode should be 500");
+            assert(err.result && err.result['message'] === 'something awful happened', "should have error message with the response");
+        }
+    });
+
+    //--------------------------------------------------------
+    // Path in baseUrl tests
+    //--------------------------------------------------------
+    it('maintains the path from the base url with no slashes', async() => {
+        nock('http://microsoft.com')
+            .get('/anything/anythingextra')
+            .reply(200, {
+                url: 'http://microsoft.com/anything/anythingextra',
+                data: null,
+                json: null
+            });
+
+        // Arrange
+        let rest = new restm.RestClient('typed-rest-client-tests', 'http://microsoft.com/anything');
+
+        // Act
+        let restRes: restm.IRestResponse<HttpData> = await rest.get<HttpData>('anythingextra');
+
+        // Assert
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com/anything/anythingextra');
+    });
+
+    it('maintains the path from the base url with double slashes', async() => {
+        nock('http://microsoft.com')
+            .get('/anything/anythingextra')
+            .reply(200, {
+                url: 'http://microsoft.com/anything/anythingextra',
+                data: null,
+                json: null
+            });
+
+        // Arrange
+        let rest = new restm.RestClient('typed-rest-client-tests', 'http://microsoft.com/anything/');
+
+        // Act
+        let restRes: restm.IRestResponse<HttpData> = await rest.get<HttpData>('anythingextra');
+
+        // Assert
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com/anything/anythingextra');
+    });
+
+    it('maintains the path from the base url with multiple parts', async() => {
+        nock('http://microsoft.com')
+            .get('/anything/extrapart/anythingextra')
+            .reply(200, {
+                url: 'http://microsoft.com/anything/extrapart/anythingextra',
+                data: null,
+                json: null
+            });
+        
+        // Arrange
+        let rest = new restm.RestClient('typed-rest-client-tests', 'http://microsoft.com/anything/extrapart');
+
+        // Act
+        let restRes: restm.IRestResponse<HttpData> = await rest.get<HttpData>('anythingextra');
+
+        // Assert
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com/anything/extrapart/anythingextra');
+    });
+
+    it('maintains the path from the base url where request has multiple parts', async() => {
+        nock('http://microsoft.com')
+            .get('/anything/anythingextra/moreparts')
+            .reply(200, {
+                url: 'http://microsoft.com/anything/anythingextra/moreparts',
+                data: null,
+                json: null
+            });
+        
+        // Arrange
+        let rest = new restm.RestClient('typed-rest-client-tests', 'http://microsoft.com/anything');
+
+        // Act
+        let restRes: restm.IRestResponse<HttpData> = await rest.get<HttpData>('anythingextra/moreparts');
+
+        // Assert
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com/anything/anythingextra/moreparts');
+    });
+
+    it('maintains the path from the base url where both have multiple parts', async() => {
+        nock('http://microsoft.com')
+            .get('/anything/multiple/anythingextra/moreparts')
+            .reply(200, {
+                url: 'http://microsoft.com/anything/multiple/anythingextra/moreparts',
+                data: null,
+                json: null
+            });
+        
+        // Arrange
+        let rest = new restm.RestClient('typed-rest-client-tests', 'http://microsoft.com/anything/multiple');
+
+        // Act
+        let restRes: restm.IRestResponse<HttpData> = await rest.get<HttpData>('anythingextra/moreparts');
+
+        // Assert
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com/anything/multiple/anythingextra/moreparts');
+    });
+
+    it('maintains the path from the base url where request has query parameters', async() => {
+        nock('http://microsoft.com')
+            .get('/anything/multiple/anythingextra/moreparts')
+            .query({
+                foo: 'bar',
+                baz: 'top'
+            })
+            .reply(200, {
+                url: 'http://microsoft.com/anything/multiple/anythingextra/moreparts?foo=bar&baz=top',
+                data: null,
+                json: null,
+                args: {foo: 'bar', baz: 'top'}
+            });
+        // Arrange
+        let rest = new restm.RestClient('typed-rest-client-tests', 'http://microsoft.com/anything/multiple');
+
+        // Act
+        let restRes: restm.IRestResponse<HttpData> = await rest.get<HttpData>('anythingextra/moreparts?foo=bar&baz=top');
+
+        // Assert
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+        assert(restRes.result && restRes.result.url === 'http://microsoft.com/anything/multiple/anythingextra/moreparts?foo=bar&baz=top');
+        assert(restRes.result && restRes.result.args.foo === 'bar');
+        assert(restRes.result && restRes.result.args.baz === 'top');
+    });
+
+    //
+    // getUrl path tests
+    //
+    it('resolves a just host resource and no baseUrl', async() => {
+        let res: string = util.getUrl('http://microsoft.com');
+        assert(res === 'http://microsoft.com', "should be http://microsoft.com");
+    });
+
+    it('resolves a empty resource with baseUrl', async() => {
+        let res: string = util.getUrl('', 'http://microsoft.com');
+        assert(res === 'http://microsoft.com', "should be http://microsoft.com");
+    });
+
+    it('resolves a null resource with baseUrl', async() => {
+        let res: string = util.getUrl(null, 'http://microsoft.com');
+        assert(res === 'http://microsoft.com', "should be http://microsoft.com");
+    });
+
+    it('resolves a full resource and no baseUrl', async() => {
+        let res: string = util.getUrl('http://microsoft.com/get?x=y&a=b');
+        assert(res === 'http://microsoft.com/get?x=y&a=b', `should be http://microsoft.com/get?x=y&a=b but is ${res}`);
+    });
+
+    it('resolves a rooted path resource with host baseUrl', async() => {
+        let res: string = util.getUrl('/get/foo', 'http://microsoft.com');
+        assert(res === 'http://microsoft.com/get/foo', `should be http://microsoft.com/get/foo but is ${res}`);
+    });
+
+    it('resolves a relative path resource with host baseUrl', async() => {
+        let res: string = util.getUrl('get/foo', 'http://microsoft.com');
+        assert(res === 'http://microsoft.com/get/foo', `should be http://microsoft.com/get/foo but is ${res}`);
+    });
+
+    it('resolves a rooted path resource with pathed baseUrl', async() => {
+        let res: string = util.getUrl('/get/foo', 'http://microsoft.com/bar');
+        assert(res === 'http://microsoft.com/get/foo', "should be http://microsoft.com/get/foo");
+    });
+
+    it('resolves a relative path resource with pathed baseUrl', async() => {
+        let res: string = util.getUrl('get/foo', 'http://microsoft.com/bar');
+        assert(res === 'http://microsoft.com/bar/get/foo', `should be http://microsoft.com/bar/get/foo but is ${res}`);
+    });
+});

--- a/test/units/tsconfig.json
+++ b/test/units/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": false,
+        "sourceMap": false
+    }
+}


### PR DESCRIPTION
Switched tests to use nock to spoof Http requests instead of connecting to httpBin. Eliminates timeout failures for tests and allows offline testing. Added tests to ensure that response bodies are included when error is thrown.

Fixes #72 and closes Microsoft/vsts-node-api#34 