### PR TITLE
Exposed HEAD functionality to Rest Client

### DIFF
--- a/lib/RestClient.ts
+++ b/lib/RestClient.ts
@@ -77,6 +77,21 @@ export class RestClient {
     }
 
     /**
+     * Gets the headers that would be returned with a GET request
+     * Be aware that not found returns a null.  Other error conditions reject the promise
+     * @param {string} resource - fully qualified url or relative path
+     * @param {IRequestOptions} requestOptions - (optional) requestOptions object
+     */
+    public async head<T>(resource: string,
+        options?: IRequestOptions): Promise<IRestResponse<T>> {
+
+        let url: string = util.getUrl(resource, this._baseUrl);
+        let res: httpm.HttpClientResponse = await this.client.head(url,
+            this._headersFromOptions(options));
+        return this._processResponse<T>(res, options);
+    }
+
+    /**
      * Deletes a resource from an endpoint
      * Be aware that not found returns a null.  Other error conditions reject the promise
      * @param {string} resource - fully qualified or relative url
@@ -128,6 +143,8 @@ export class RestClient {
         let res: httpm.HttpClientResponse = await this.client.patch(url, data, headers);
         return this._processResponse<T>(res, options);
     }
+
+
 
     /**
      * Replaces resource(s) from an endpoint

--- a/test/units/resttests.ts
+++ b/test/units/resttests.ts
@@ -64,6 +64,14 @@ describe('Rest Tests', function () {
         assert(restRes.result && restRes.result.url === 'http://microsoft.com');
     });
 
+    it('does basic head request', async() => {
+        nock('http://microsoft.com')
+            .head('/')
+            .reply(200);
+        let restRes: restm.IRestResponse<HttpData> = await _restMic.head<HttpData>('');
+        assert(restRes.statusCode == 200, "statusCode should be 200");
+    });
+
     it('creates a resource', async() => {
         nock('http://microsoft.com')
             .post('/')


### PR DESCRIPTION
Was already available in HttpClient, just exposed it to RestClient.

Fixes #81 