### PR TITLE
Adding optional date reviver

### DIFF
--- a/lib/RestClient.ts
+++ b/lib/RestClient.ts
@@ -21,7 +21,7 @@ export interface IRequestOptions {
 
     responseProcessor?: Function,
     //Dates aren't automatically deserialized by JSON, this adds a date reviver to ensure they aren't just left as strings
-    reviveDates?: boolean
+    deserializeDates?: boolean
 }
 
 export class RestClient {
@@ -205,7 +205,7 @@ export class RestClient {
             try {
                 let contents: string = await res.readBody();
                 if (contents && contents.length > 0) {
-                    if (options && options.reviveDates) {
+                    if (options && options.deserializeDates) {
                         obj = JSON.parse(contents, RestClient.dateTimeReviver);
                     } else {
                         obj = JSON.parse(contents);

--- a/lib/RestClient.ts
+++ b/lib/RestClient.ts
@@ -19,7 +19,9 @@ export interface IRequestOptions {
     // since accept is defaulted, set additional headers if needed
     additionalHeaders?: ifm.IHeaders,
 
-    responseProcessor?: Function
+    responseProcessor?: Function,
+    //Dates aren't automatically deserialized by JSON, this adds a date reviver to ensure they aren't just left as strings
+    reviveDates?: boolean
 }
 
 export class RestClient {
@@ -172,6 +174,17 @@ export class RestClient {
         return headers;
     }
 
+    private static dateTimeReviver(key: any, value: any): any {
+        if (typeof value === 'string'){
+            let a = new Date(value);
+            if (!isNaN(a.valueOf())) {
+                return a;
+            }
+        }
+
+        return value;
+    }
+
     private async _processResponse<T>(res: httpm.HttpClientResponse, options: IRequestOptions): Promise<IRestResponse<T>> {
         return new Promise<IRestResponse<T>>(async (resolve, reject) => {
             const statusCode: number = res.message.statusCode;
@@ -192,7 +205,11 @@ export class RestClient {
             try {
                 let contents: string = await res.readBody();
                 if (contents && contents.length > 0) {
-                    obj = JSON.parse(contents);
+                    if (options && options.reviveDates) {
+                        obj = JSON.parse(contents, RestClient.dateTimeReviver);
+                    } else {
+                        obj = JSON.parse(contents);
+                    }
                     if (options && options.responseProcessor) {
                         response.result = options.responseProcessor(obj);
                     }

--- a/lib/RestClient.ts
+++ b/lib/RestClient.ts
@@ -174,7 +174,7 @@ export class RestClient {
         return headers;
     }
 
-    private static dateTimeReviver(key: any, value: any): any {
+    private static dateTimeDeserializer(key: any, value: any): any {
         if (typeof value === 'string'){
             let a = new Date(value);
             if (!isNaN(a.valueOf())) {
@@ -206,7 +206,7 @@ export class RestClient {
                 let contents: string = await res.readBody();
                 if (contents && contents.length > 0) {
                     if (options && options.deserializeDates) {
-                        obj = JSON.parse(contents, RestClient.dateTimeReviver);
+                        obj = JSON.parse(contents, RestClient.dateTimeDeserializer);
                     } else {
                         obj = JSON.parse(contents);
                     }

--- a/test/units/resttests.ts
+++ b/test/units/resttests.ts
@@ -34,7 +34,7 @@ describe('Rest Tests', function () {
     it('constructs', () => {
         this.timeout(1000);
 
-        let rest: restm.RestClient = new restm.RestClient('typed-test-client-tests');
+        let rest: restm.RestClient = new restm.RestClient('typed-rest-client-tests');
         assert(rest, 'rest client should not be null');
     })
 
@@ -62,6 +62,28 @@ describe('Rest Tests', function () {
         let restRes: restm.IRestResponse<HttpData> = await _restMic.get<HttpData>('');
         assert(restRes.statusCode == 200, "statusCode should be 200");
         assert(restRes.result && restRes.result.url === 'http://microsoft.com');
+    });
+
+    it('gets a resource and correctly revives its Date property', async() => {
+        const dateObject: Date = new Date();
+        nock('http://microsoft.com')
+            .get('/date')
+            .reply(200, {
+                json: {dateProperty: dateObject.toDateString()}
+            });
+        const restRes: restm.IRestResponse<HttpData> = await _rest.get<HttpData>('http://microsoft.com/date', {reviveDates: true});
+        assert(restRes.result && restRes.result.json.dateProperty.getTime != undefined);
+    });
+
+    it('gets a resource and doesn\'t revive its non-Date property', async() => {
+        const nonDateObject: string = "stringObject";
+        nock('http://microsoft.com')
+            .get('/date')
+            .reply(200, {
+                json: {nonDateProperty: nonDateObject}
+            });
+        const restRes: restm.IRestResponse<HttpData> = await _rest.get<HttpData>('http://microsoft.com/date', {reviveDates: true});
+        assert(restRes.result && typeof(restRes.result.json.nonDateProperty) == 'string' && restRes.result.json.nonDateProperty == "stringObject");
     });
 
     it('creates a resource', async() => {

--- a/test/units/resttests.ts
+++ b/test/units/resttests.ts
@@ -64,14 +64,19 @@ describe('Rest Tests', function () {
         assert(restRes.result && restRes.result.url === 'http://microsoft.com');
     });
 
-    it('gets a resource and correctly revives its Date property', async() => {
+    it('gets a resource and correctly deserializes its Date property', async() => {
+        //Arrange
         const dateObject: Date = new Date(2018, 9, 24, 10, 54, 11, 1);
         nock('http://microsoft.com')
             .get('/date')
             .reply(200, {
                 json: {dateProperty: dateObject.toDateString()}
             });
-        const restRes: restm.IRestResponse<HttpData> = await _rest.get<HttpData>('http://microsoft.com/date', {reviveDates: true});
+        
+        //Act
+        const restRes: restm.IRestResponse<HttpData> = await _rest.get<HttpData>('http://microsoft.com/date', {deserializeDates: true});
+
+        //Assert
         assert(restRes.result);
         const dateProperty: Date = restRes.result.json.dateProperty;
         assert(dateProperty.getTime, 'dateProperty should have a getTime method');
@@ -81,14 +86,19 @@ describe('Rest Tests', function () {
 
     });
 
-    it('gets a resource and doesn\'t revive its non-Date property', async() => {
+    it('gets a resource and doesn\'t deserialize its non-Date property', async() => {
+        //Arrange
         const nonDateObject: string = 'stringObject';
         nock('http://microsoft.com')
             .get('/date')
             .reply(200, {
                 json: {nonDateProperty: nonDateObject}
             });
-        const restRes: restm.IRestResponse<HttpData> = await _rest.get<HttpData>('http://microsoft.com/date', {reviveDates: true});
+
+        //Act
+        const restRes: restm.IRestResponse<HttpData> = await _rest.get<HttpData>('http://microsoft.com/date', {deserializeDates: true});
+
+        //Assert
         assert(restRes.result);
         assert(restRes.statusCode == 200, "statusCode should be 200");
         assert.equal(typeof(restRes.result.json.nonDateProperty), 'string');

--- a/test/units/resttests.ts
+++ b/test/units/resttests.ts
@@ -65,25 +65,33 @@ describe('Rest Tests', function () {
     });
 
     it('gets a resource and correctly revives its Date property', async() => {
-        const dateObject: Date = new Date();
+        const dateObject: Date = new Date(2018, 9, 24, 10, 54, 11, 1);
         nock('http://microsoft.com')
             .get('/date')
             .reply(200, {
                 json: {dateProperty: dateObject.toDateString()}
             });
         const restRes: restm.IRestResponse<HttpData> = await _rest.get<HttpData>('http://microsoft.com/date', {reviveDates: true});
-        assert(restRes.result && restRes.result.json.dateProperty.getTime != undefined);
+        assert(restRes.result);
+        const dateProperty: Date = restRes.result.json.dateProperty;
+        assert(dateProperty.getTime, 'dateProperty should have a getTime method');
+        assert.equal(dateProperty.getFullYear(), 2018);
+        assert.equal(dateProperty.getMonth(), 9);
+        assert.equal(dateProperty.getDate(), 24);
+
     });
 
     it('gets a resource and doesn\'t revive its non-Date property', async() => {
-        const nonDateObject: string = "stringObject";
+        const nonDateObject: string = 'stringObject';
         nock('http://microsoft.com')
             .get('/date')
             .reply(200, {
                 json: {nonDateProperty: nonDateObject}
             });
         const restRes: restm.IRestResponse<HttpData> = await _rest.get<HttpData>('http://microsoft.com/date', {reviveDates: true});
-        assert(restRes.result && typeof(restRes.result.json.nonDateProperty) == 'string' && restRes.result.json.nonDateProperty == "stringObject");
+        assert(restRes.result);
+        assert.equal(typeof(restRes.result.json.nonDateProperty), 'string');
+        assert.equal(restRes.result.json.nonDateProperty, 'stringObject');
     });
 
     it('creates a resource', async() => {

--- a/test/units/resttests.ts
+++ b/test/units/resttests.ts
@@ -90,6 +90,7 @@ describe('Rest Tests', function () {
             });
         const restRes: restm.IRestResponse<HttpData> = await _rest.get<HttpData>('http://microsoft.com/date', {reviveDates: true});
         assert(restRes.result);
+        assert(restRes.statusCode == 200, "statusCode should be 200");
         assert.equal(typeof(restRes.result.json.nonDateProperty), 'string');
         assert.equal(restRes.result.json.nonDateProperty, 'stringObject');
     });


### PR DESCRIPTION
Builds off of @etiago's closed PR https://github.com/Microsoft/typed-rest-client/pull/69, makes it optional instead of mandatory to fix issues with back compat, and adds tests.

Fixes #68 