### PR TITLE
Support IE11 by targeting es5

### DIFF
--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -4,9 +4,12 @@
 import url = require("url");
 import http = require("http");
 import https = require("https");
+import objectAssign = require('object-assign');
 import tunnel = require("tunnel");
 import ifm = require('./Interfaces');
 import fs = require('fs');
+
+//require('es6-promise').polyfill();
 
 export enum HttpCodes {
     OK = 200,
@@ -414,11 +417,11 @@ export class HttpClient implements ifm.IHttpClient {
             // we don't want to set NODE_TLS_REJECT_UNAUTHORIZED=0 since that will affect request for entire process
             // http.RequestOptions doesn't expose a way to modify RequestOptions.agent.options
             // we have to cast it to any and change it directly
-            agent.options = Object.assign(agent.options || {}, { rejectUnauthorized: false });
+            agent.options = objectAssign(agent.options || {}, { rejectUnauthorized: false });
         }
 
         if (usingSsl && this._certConfig) {
-            agent.options = Object.assign(agent.options || {}, { ca: this._ca, cert: this._cert, key: this._key, passphrase: this._certConfig.passphrase });
+            agent.options = objectAssign(agent.options || {}, { ca: this._ca, cert: this._cert, key: this._key, passphrase: this._certConfig.passphrase });
         }
 
         return agent;

--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -9,8 +9,6 @@ import tunnel = require("tunnel");
 import ifm = require('./Interfaces');
 import fs = require('fs');
 
-//require('es6-promise').polyfill();
-
 export enum HttpCodes {
     OK = 200,
     MultipleChoices = 300,

--- a/lib/RestClient.ts
+++ b/lib/RestClient.ts
@@ -7,6 +7,8 @@ import httpm = require('./HttpClient');
 import ifm = require("./Interfaces");
 import util = require("./Util");
 
+require('es6-promise').polyfill();
+
 export interface IRestResponse<T> {
     statusCode: number,
     result: T | null

--- a/lib/handlers/ntlm.ts
+++ b/lib/handlers/ntlm.ts
@@ -8,6 +8,8 @@ import https = require("https");
 var _ = require("underscore");
 var ntlm = require("../opensource/node-http-ntlm/ntlm");
 
+require('es6-promise').polyfill();
+
 interface INtlmOptions {
     username?: string,
     password?: string,

--- a/package-lock.json
+++ b/package-lock.json
@@ -130,6 +130,11 @@
       "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
       "dev": true
     },
+    "es6-promise": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
+      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg=="
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -368,6 +373,11 @@
           "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
         }
       }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
   },
   "dependencies": {
     "nock": "9.6.1",
+    "object-assign": "4.1.1",
+    "es6-promise": "4.2.5",
     "tunnel": "0.0.4",
     "underscore": "1.8.3"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,14 @@
 {
-    "compilerOptions": {
-        "target": "es2015",
-        "module": "commonjs",
-        "moduleResolution": "node",
-        "typeRoots": [ "node_modules/@types" ], 
-        "declaration": true,
-        "outDir": "_build",
-        "forceConsistentCasingInFileNames": true
-    },
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "typeRoots": [ "node_modules/@types" ],
+    "declaration": true,
+    "outDir": "_build",
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["es2015"]
+  },
     "files": [
         "lib/Index.ts",
         "lib/Handlers.ts"


### PR DESCRIPTION
I think this should allow us to target es5. The only things we use that can't be automatically converted by typescript are Promise and Object.assign, both of which I polyfilled.

Fixes #62