### PR TITLE
Update links to test files in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ $ npm run units
 
 See [samples](./samples) for complete coding examples
 
-Also see [rest](./test/resttests.ts) and [http](./test/httptests.ts) tests for detailed examples.
+Also see [rest](./test/tests/resttests.ts) and [http](./test/tests/httptests.ts) tests for detailed examples.
 
 ## Errors
 
 ### http
 The http client does not throw unless truly exceptional.  A request that successfully executes resulting in a 404, 500 etc... will return a response object with a status code and a body.  Redirects (3xx) will be followed by default.
 
-See [http tests](./test/httptests.ts) for detailed examples.
+See [http tests](./test/tests/httptests.ts) for detailed examples.
 
 ### rest
 The rest client is a high level client which uses the http client.  It's responsibility is to turn a body into a typed resource object.  
@@ -66,7 +66,7 @@ A 404 will not throw but the result object will be null and the result statusCod
 
 Other 4xx and 5xx errors will throw.  The status code will be attached to the error object.  If a restful error object is returned ({ message: xxx}), then the error message will be that.  Otherwise, it will be a generic, "Failed Request: (xxx)".
 
-See [rest tests](./test/resttests.ts) for detailed examples.
+See [rest tests](./test/tests/resttests.ts) for detailed examples.
 
 ## Node Support
 


### PR DESCRIPTION
The folder seems to have changed in https://github.com/Microsoft/typed-rest-client/commit/e268bebc23aa8ec92475a101448f5b634d42eb2f#diff-cd48b3466cac686a136aa1ca179b659b which means the links aren't working.