### PR TITLE
Expose processResponse method

### DIFF
--- a/lib/RestClient.ts
+++ b/lib/RestClient.ts
@@ -60,7 +60,7 @@ export class RestClient {
         let url: string = util.getUrl(requestUrl, this._baseUrl);
         let res: httpm.HttpClientResponse = await this.client.options(url,
             this._headersFromOptions(options));
-        return this._processResponse<T>(res, options);
+        return this.processHttpResponse<T>(res, options);
     }
 
     /**
@@ -75,7 +75,7 @@ export class RestClient {
         let url: string = util.getUrl(resource, this._baseUrl);
         let res: httpm.HttpClientResponse = await this.client.get(url,
             this._headersFromOptions(options));
-        return this._processResponse<T>(res, options);
+        return this.processHttpResponse<T>(res, options);
     }
 
     /**
@@ -90,7 +90,7 @@ export class RestClient {
         let url: string = util.getUrl(resource, this._baseUrl);
         let res: httpm.HttpClientResponse = await this.client.del(url,
             this._headersFromOptions(options));
-        return this._processResponse<T>(res, options);
+        return this.processHttpResponse<T>(res, options);
     }
 
     /**
@@ -109,7 +109,7 @@ export class RestClient {
 
         let data: string = JSON.stringify(resources, null, 2);
         let res: httpm.HttpClientResponse = await this.client.post(url, data, headers);
-        return this._processResponse<T>(res, options);
+        return this.processHttpResponse<T>(res, options);
     }
 
     /**
@@ -128,7 +128,7 @@ export class RestClient {
 
         let data: string = JSON.stringify(resources, null, 2);
         let res: httpm.HttpClientResponse = await this.client.patch(url, data, headers);
-        return this._processResponse<T>(res, options);
+        return this.processHttpResponse<T>(res, options);
     }
 
     /**
@@ -147,7 +147,7 @@ export class RestClient {
 
         let data: string = JSON.stringify(resources, null, 2);
         let res: httpm.HttpClientResponse = await this.client.put(url, data, headers);
-        return this._processResponse<T>(res, options);
+        return this.processHttpResponse<T>(res, options);
     }
 
     public async uploadStream<T>(verb: string,
@@ -159,7 +159,7 @@ export class RestClient {
         let headers: ifm.IHeaders = this._headersFromOptions(options, true);
 
         let res: httpm.HttpClientResponse = await this.client.sendStream(verb, url, stream, headers);
-        return this._processResponse<T>(res, options);
+        return this._processHttpResponse<T>(res, options);
     }
 
     private _headersFromOptions(options: IRequestOptions, contentType?: boolean): ifm.IHeaders {
@@ -185,7 +185,7 @@ export class RestClient {
         return value;
     }
 
-    private async _processResponse<T>(res: httpm.HttpClientResponse, options: IRequestOptions): Promise<IRestResponse<T>> {
+    public async processHttpResponse<T>(res: httpm.HttpClientResponse, options: IRequestOptions): Promise<IRestResponse<T>> {
         return new Promise<IRestResponse<T>>(async (resolve, reject) => {
             const statusCode: number = res.message.statusCode;
 


### PR DESCRIPTION
I don't know if we actually want to do this, but if we're not going to expose HEAD for the restClient, it could be useful to at least expose processResponse for users who want to have a consistent way of accessing responses. A good example of this is azure-devops-node-api, which would probably have to replicate this code if its not exposed in order to solve [this issue](https://github.com/Microsoft/azure-devops-node-api/issues/247).