### PR TITLE
Headers checking in headersFromOptions is now case sensitive

### DIFF
--- a/lib/RestClient.ts
+++ b/lib/RestClient.ts
@@ -168,7 +168,17 @@ export class RestClient {
         headers["Accept"] = options.acceptHeader || "application/json";
 
         if (contentType) {
-            headers["Content-Type"] = headers["Content-Type"] || 'application/json; charset=utf-8';
+            let found: boolean = false;
+
+            for (let header in headers) {
+                if (header.toLowerCase() == "content-type") {
+                    found = true;
+                }
+            }
+
+            if (!found) {
+                headers["Content-Type"] = 'application/json; charset=utf-8';
+            }
         }
 
         return headers;


### PR DESCRIPTION
In case user specifies a custom Content-Type header (necessary at example in case we are using uploadStream to upload a file via mutipart/formdata standard (RFC 2388) the default one will not be added.
The problem is that the check over Content-Type header is case sensitive, so if you added a content-type header, this will not be detected and used correctly.

This makes the comparison case sensitive.

Closes #96 