### PR TITLE
Add header merging from constructor and individual methods

### DIFF
--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -324,7 +324,7 @@ export class HttpClient implements ifm.IHttpClient {
         }
     }
 
-    private _prepareRequest(method: string, requestUrl: string, headers: any): ifm.IRequestInfo {
+    private _prepareRequest(method: string, requestUrl: string, headers: ifm.IHeaders): ifm.IRequestInfo {
         const info: ifm.IRequestInfo = <ifm.IRequestInfo>{};
 
         info.parsedUrl = url.parse(requestUrl);
@@ -336,7 +336,7 @@ export class HttpClient implements ifm.IHttpClient {
         info.options.port = info.parsedUrl.port ? parseInt(info.parsedUrl.port) : defaultPort;
         info.options.path = (info.parsedUrl.pathname || '') + (info.parsedUrl.search || '');
         info.options.method = method;
-        info.options.headers = headers || {};
+        info.options.headers = this._mergeHeaders(headers);
         info.options.headers["User-Agent"] = this.userAgent;
         info.options.agent = this._getAgent(requestUrl);
 
@@ -348,6 +348,14 @@ export class HttpClient implements ifm.IHttpClient {
         }
 
         return info;
+    }
+
+    private _mergeHeaders(headers: ifm.IHeaders) : ifm.IHeaders {
+        if (this.requestOptions && this.requestOptions.headers) {
+            return Object.assign({}, this.requestOptions.headers, headers);
+        }
+
+        return headers || {};
     }
 
     private _getAgent(requestUrl: string) {

--- a/test/tests/httptests.ts
+++ b/test/tests/httptests.ts
@@ -81,6 +81,40 @@ describe('Http Tests', function () {
         assert(creds === 'PAT:' + token, "creds should be the token");
         assert(obj.url === "http://httpbin.org/get");
     });
+    
+    it('does basic http get request with default headers', async() => {
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-rest-client-tests', [], {
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+            }
+        });
+        let res: httpm.HttpClientResponse = await http.get('http://httpbin.org/get');
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody(); 
+        let obj:any = JSON.parse(body);
+        assert(obj.headers.Accept === 'application/json', "Accept header should be 'application/json'");
+        assert(obj.headers['Content-Type'] === 'application/json', "Content-Type header should be 'application/json'");
+        assert(obj.url === "http://httpbin.org/get");
+    });
+    
+    it('does basic http get request with merged headers', async() => {
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-rest-client-tests', [], {
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+            }
+        });
+        let res: httpm.HttpClientResponse = await http.get('http://httpbin.org/get', {
+            'Content-Type': 'application/x-www-form-urlencoded'
+        });
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody(); 
+        let obj:any = JSON.parse(body);
+        assert(obj.headers.Accept === 'application/json', "Accept header should be 'application/json'");
+        assert(obj.headers['Content-Type'] === 'application/x-www-form-urlencoded', "Content-Type header should be 'application/x-www-form-urlencoded'");
+        assert(obj.url === "http://httpbin.org/get");
+    });
 
     it('pipes a get request', () => {
         return new Promise<string>(async (resolve, reject) => {

--- a/test/units/httptests.ts
+++ b/test/units/httptests.ts
@@ -105,6 +105,62 @@ describe('Http Tests', function () {
         assert(obj.success, "Authentication should succeed");
     });
 
+    it('does basic http get request with default headers', async() => {
+        //Set nock for correct credentials
+        nock('http://microsoft.com', {
+            reqheaders: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+            }
+        })
+            .get('/')
+            .reply(200, {
+            success: true,
+            source: "nock"
+        });
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-rest-client-tests', [], {
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+            }
+        });
+        let res: httpm.HttpClientResponse = await http.get('http://microsoft.com');
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();      
+        let obj: any = JSON.parse(body);
+        assert(obj.source === "nock", "http get request should be intercepted by nock");
+        assert(obj.success, "Headers should send");
+    });
+
+    it('does basic http get request with merged headers', async() => {
+        //Set nock for correct credentials
+        nock('http://microsoft.com', {
+            reqheaders: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/x-www-form-urlencoded'
+            }
+        })
+            .get('/')
+            .reply(200, {
+            success: true,
+            source: "nock"
+        });
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-rest-client-tests', [], {
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+            }
+        });
+        let res: httpm.HttpClientResponse = await http.get('http://microsoft.com', {
+            'Content-Type': 'application/x-www-form-urlencoded'
+        });
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();      
+        let obj: any = JSON.parse(body);
+        assert(obj.source === "nock", "http get request should be intercepted by nock");
+        assert(obj.success, "Headers should merge/send");
+    });
+
     it('pipes a get request', () => {
         nock('http://microsoft.com')
             .get('/')


### PR DESCRIPTION
This change fixes a bug where the headers passed into the constructor was not being used and if the function gets headers they did not get merged.

Resolves #65.

I didn't see the other PR until after I did this work,(I just missed it otherwise I would not have done this) but I thought that it did not solve the problem the same way anyway and I already these changes and tested them. This is specific to merging headers as other rest clients due. 

Feel free to close, just didn't want the code completely wasted.