### PR TITLE
Added private token handler

### DIFF
--- a/lib/handlers/privatetoken.ts
+++ b/lib/handlers/privatetoken.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import ifm = require('../Interfaces');
+
+export class PrivateTokenCredentialHandler implements ifm.IRequestHandler {
+    token: string;
+
+    constructor(token: string) {
+        this.token = token;
+    }
+
+    prepareRequest(options:any): void {
+        options.headers['Private-Token'] = this.token;
+    }
+
+    // This handler cannot handle 401
+    canHandleAuthentication(response: ifm.IHttpClientResponse): boolean {
+        return false;
+    }
+
+    handleAuthentication(httpClient: ifm.IHttpClient, requestInfo: ifm.IRequestInfo, objs): Promise<ifm.IHttpClientResponse> {
+        return null;
+    }
+}


### PR DESCRIPTION
Several tools, like Gitlab, do support authentication through the Private-Token header field and related PAT.
Check this for further info https://docs.gitlab.com/ee/api/#personal-access-tokens 

I created a new handler that will do just that.