### PR TITLE
Add support to handle gzipped requests with tests

### DIFF
--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -70,7 +70,7 @@ export class HttpClientResponse implements ifm.IHttpClientResponse {
                     });
             } else {
                 let output = Buffer.alloc(0);
-                this.message.on('data', (chunk) => {
+                this.message.on('data', (chunk: any) => {
                     output = Buffer.concat([output, chunk]);
                 });
                 this.message.on('end', () => {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "tunnel": "0.0.4",
-    "underscore": "1.8.3"
+    "underscore": "1.8.3",
+    "zlib": "^1.0.5"
   }
 }

--- a/test/tests/httptests.ts
+++ b/test/tests/httptests.ts
@@ -54,6 +54,22 @@ describe('Http Tests', function () {
         assert(obj.url === "https://httpbin.org/get");
     });
 
+    it('does basic http get request using gzip', async() => {
+        let res: httpm.HttpClientResponse = await _http.get('http://httpbin.org/gzip');
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();
+        let obj:any = JSON.parse(body);
+        assert(obj.headers.Host === "httpbin.org");
+    });
+
+    it('does basic https get request using gzip', async() => {
+        let res: httpm.HttpClientResponse = await _http.get('https://httpbin.org/gzip');
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();
+        let obj:any = JSON.parse(body);
+        assert(obj.headers.Host === "httpbin.org");
+    });
+
     it('does basic http get request with basic auth', async() => {
         let bh: hm.BasicCredentialHandler = new hm.BasicCredentialHandler('johndoe', 'password');
         let http: httpm.HttpClient = new httpm.HttpClient('typed-rest-client-tests', [bh]);


### PR DESCRIPTION
Added support for gzip to HttpClient.ts which addresses this PR:

https://github.com/microsoft/typed-rest-client/issues/148

I found similar code on SO here and adapted it for this package.

https://stackoverflow.com/questions/12148948/how-do-i-ungzip-decompress-a-nodejs-requests-module-gzip-response-body