### PR TITLE
Adding support for text/plain content type responses

### DIFF
--- a/lib/RestClient.ts
+++ b/lib/RestClient.ts
@@ -221,11 +221,6 @@ export class RestClient {
                     } else {
                         obj = JSON.parse(contents);
                     }
-                    // If the response was text/plain, JSON.parse will return undefined
-                    if (obj === undefined) {
-                        // contents was already the string in response
-                        obj = contents;
-                    }
                     if (options && options.responseProcessor) {
                         response.result = options.responseProcessor(obj);
                     }
@@ -236,7 +231,9 @@ export class RestClient {
                 response.headers = res.message.headers;
             }
             catch (err) {
-                // Invalid resource (contents not json);  leaving result obj null
+                // Contents not json, setting response to raw contents (text/plain content-type)
+                obj = contents;
+                response.result = obj;
             }
 
             // note that 3xx redirects are handled by the http layer.

--- a/lib/RestClient.ts
+++ b/lib/RestClient.ts
@@ -221,6 +221,11 @@ export class RestClient {
                     } else {
                         obj = JSON.parse(contents);
                     }
+                    // If the response was text/plain, JSON.parse will return undefined
+                    if (obj === undefined) {
+                        // contents was already the string in response
+                        obj = contents;
+                    }
                     if (options && options.responseProcessor) {
                         response.result = options.responseProcessor(obj);
                     }


### PR DESCRIPTION
Currently, the RestClient only accepts json/application content type responses, and will return null for text/plain content type responses. This change will set the response result to the raw content if JSON parsing fails (eg contents are not a JSON). This will allow for text/plain content type responses.