### PR TITLE
Support adding query-parameters in RestClient Requests.

### DIFF
--- a/lib/Interfaces.ts
+++ b/lib/Interfaces.ts
@@ -73,8 +73,12 @@ export interface ICertConfiguration {
 }
 
 export interface IRequestQueryParams {
-    eq?: string,
-    sep?: string,
+    options?: {
+        separator?: string,
+        arrayFormat?: string,
+        shouldAllowDots?: boolean
+        shouldOnlyEncodeValues?: boolean,
+    },
     params: {
         [name: string]: string | number | (string | number)[]
     }

--- a/lib/Interfaces.ts
+++ b/lib/Interfaces.ts
@@ -71,3 +71,12 @@ export interface ICertConfiguration {
     keyFile?: string;
     passphrase?: string;
 }
+
+export interface IRequestQueryParams {
+    eq?: string,
+    sep?: string,
+    params: {
+        [name: string]: string | number | (string | number)[]
+    }
+}
+

--- a/lib/RestClient.ts
+++ b/lib/RestClient.ts
@@ -72,7 +72,7 @@ export class RestClient {
     public async get<T>(resource: string,
         options?: IRequestOptions): Promise<IRestResponse<T>> {
 
-        let url: string = util.getUrl(resource, this._baseUrl, options);
+        let url: string = util.getUrl(resource, this._baseUrl, (options || {}).queryParameters);
         let res: httpm.HttpClientResponse = await this.client.get(url,
             this._headersFromOptions(options));
         return this._processResponse<T>(res, options);

--- a/lib/RestClient.ts
+++ b/lib/RestClient.ts
@@ -5,14 +5,6 @@ import httpm = require('./HttpClient');
 import ifm = require("./Interfaces");
 import util = require("./Util");
 
-export interface IRequestQueryParams {
-    eq?: string,
-    sep?: string,
-    params: {
-        [name: string]: string | number | (string | number)[]
-    }
-}
-
 export interface IRestResponse<T> {
     statusCode: number,
     result: T | null,
@@ -29,7 +21,7 @@ export interface IRequestOptions {
     responseProcessor?: Function,
     //Dates aren't automatically deserialized by JSON, this adds a date reviver to ensure they aren't just left as strings
     deserializeDates?: boolean,
-    queryParameters?: IRequestQueryParams
+    queryParameters?: ifm.IRequestQueryParams
 }
 
 export class RestClient {

--- a/lib/RestClient.ts
+++ b/lib/RestClient.ts
@@ -5,6 +5,14 @@ import httpm = require('./HttpClient');
 import ifm = require("./Interfaces");
 import util = require("./Util");
 
+export interface IRequestQueryParams {
+    eq?: string,
+    sep?: string,
+    params: {
+        [name: string]: string | number | (string | number)[]
+    }
+}
+
 export interface IRestResponse<T> {
     statusCode: number,
     result: T | null,
@@ -20,7 +28,8 @@ export interface IRequestOptions {
 
     responseProcessor?: Function,
     //Dates aren't automatically deserialized by JSON, this adds a date reviver to ensure they aren't just left as strings
-    deserializeDates?: boolean
+    deserializeDates?: boolean,
+    queryParameters?: IRequestQueryParams
 }
 
 export class RestClient {
@@ -71,7 +80,7 @@ export class RestClient {
     public async get<T>(resource: string,
         options?: IRequestOptions): Promise<IRestResponse<T>> {
 
-        let url: string = util.getUrl(resource, this._baseUrl);
+        let url: string = util.getUrl(resource, this._baseUrl, options);
         let res: httpm.HttpClientResponse = await this.client.get(url,
             this._headersFromOptions(options));
         return this._processResponse<T>(res, options);

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -3,20 +3,25 @@
 
 import * as url from 'url';
 import * as path from 'path';
+import queryString = require('querystring');
+import { IRequestOptions, IRequestQueryParams } from './RestClient';
 
 /**
  * creates an url from a request url and optional base url (http://server:8080)
  * @param {string} resource - a fully qualified url or relative path
  * @param {string} baseUrl - an optional baseUrl (http://server:8080)
- * @return {string} - resultant url 
+ * @param {IRequestOptions} options - an optional options object, could include QueryParameters e.g.
+ * @return {string} - resultant url
  */
-export function getUrl(resource: string, baseUrl?: string): string  {
+export function getUrl(resource: string, baseUrl?: string, options?: IRequestOptions): string  {
     const pathApi = path.posix || path;
+    let requestUrl = '';
+
     if (!baseUrl) {
-        return resource;
+        requestUrl = resource;
     }
     else if (!resource) {
-        return baseUrl;
+        requestUrl = baseUrl;
     }
     else {
         const base: url.Url = url.parse(baseUrl);
@@ -33,6 +38,29 @@ export function getUrl(resource: string, baseUrl?: string): string  {
             resultantUrl.pathname += '/';
         }
 
-        return url.format(resultantUrl);
+        requestUrl = url.format(resultantUrl);
     }
+
+    const queryParams = ((options || {}).queryParameters) || undefined;
+
+    return queryParams ?
+        prepareUrlWithQueryParams(requestUrl, queryParams):
+        requestUrl;
+}
+
+/**
+ *
+ * @param {string} requestUrl
+ * @param {IRequestQueryParams} queryParams
+ * @return {string} - Request's URL with Query Parameters appended/parsed.
+ */
+function prepareUrlWithQueryParams(requestUrl: string, queryParams: IRequestQueryParams): string {
+    const url: string  = requestUrl.replace(/\?$/g, '');
+    const parsedQueryParams: string = queryString.stringify(
+        queryParams.params,
+        queryParams.sep || '&',
+        queryParams.eq || '='
+    );
+
+    return `${url}?${parsedQueryParams}`;
 }

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -55,7 +55,7 @@ export function getUrl(resource: string, baseUrl?: string, options?: IRequestOpt
  * @return {string} - Request's URL with Query Parameters appended/parsed.
  */
 function prepareUrlWithQueryParams(requestUrl: string, queryParams: IRequestQueryParams): string {
-    const url: string  = requestUrl.replace(/\?$/g, '');
+    const url: string  = requestUrl.replace(/\?$/g, ''); // Clean any extra end-of-string "?" character
     const parsedQueryParams: string = queryString.stringify(
         queryParams.params,
         queryParams.sep || '&',

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -4,7 +4,6 @@
 import * as qs from 'qs';
 import * as url from 'url';
 import * as path from 'path';
-import { IRequestOptions } from './RestClient';
 import { IRequestQueryParams } from './Interfaces';
 
 /**
@@ -14,7 +13,7 @@ import { IRequestQueryParams } from './Interfaces';
  * @param {IRequestOptions} options - an optional options object, could include QueryParameters e.g.
  * @return {string} - resultant url
  */
-export function getUrl(resource: string, baseUrl?: string, options?: IRequestOptions): string  {
+export function getUrl(resource: string, baseUrl?: string, queryParams?: IRequestQueryParams): string  {
     const pathApi = path.posix || path;
     let requestUrl = '';
 
@@ -41,8 +40,6 @@ export function getUrl(resource: string, baseUrl?: string, options?: IRequestOpt
 
         requestUrl = url.format(resultantUrl);
     }
-
-    const queryParams: IRequestQueryParams = ((options || {}).queryParameters) || undefined;
 
     return queryParams ?
         getUrlWithParsedQueryParams(requestUrl, queryParams):

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+import * as qs from 'qs';
 import * as url from 'url';
 import * as path from 'path';
-import queryString = require('querystring');
 import { IRequestOptions } from './RestClient';
 import { IRequestQueryParams } from './Interfaces';
 
@@ -45,7 +45,7 @@ export function getUrl(resource: string, baseUrl?: string, options?: IRequestOpt
     const queryParams: IRequestQueryParams = ((options || {}).queryParameters) || undefined;
 
     return queryParams ?
-        prepareUrlWithQueryParams(requestUrl, queryParams):
+        getUrlWithParsedQueryParams(requestUrl, queryParams):
         requestUrl;
 }
 
@@ -55,13 +55,27 @@ export function getUrl(resource: string, baseUrl?: string, options?: IRequestOpt
  * @param {IRequestQueryParams} queryParams
  * @return {string} - Request's URL with Query Parameters appended/parsed.
  */
-function prepareUrlWithQueryParams(requestUrl: string, queryParams: IRequestQueryParams): string {
+function getUrlWithParsedQueryParams(requestUrl: string, queryParams: IRequestQueryParams): string {
     const url: string  = requestUrl.replace(/\?$/g, ''); // Clean any extra end-of-string "?" character
-    const parsedQueryParams: string = queryString.stringify(
-        queryParams.params,
-        queryParams.sep || '&',
-        queryParams.eq || '='
-    );
+    const parsedQueryParams: string = qs.stringify(queryParams.params, buildParamsStringifyOptions(queryParams));
 
-    return `${url}?${parsedQueryParams}`;
+    return `${url}${parsedQueryParams}`;
+}
+
+/**
+ * Build options for QueryParams Stringifying.
+ *
+ * @param {IRequestQueryParams} queryParams
+ * @return {object}
+ */
+function buildParamsStringifyOptions(queryParams: IRequestQueryParams): any  {
+    let options: any = {
+        addQueryPrefix: true,
+        delimiter: (queryParams.options || {}).separator || '&',
+        allowDots: (queryParams.options || {}).shouldAllowDots || false,
+        arrayFormat: (queryParams.options || {}).arrayFormat || 'repeat',
+        encodeValuesOnly: (queryParams.options || {}).shouldOnlyEncodeValues || true
+    }
+
+    return options;
 }

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -4,7 +4,8 @@
 import * as url from 'url';
 import * as path from 'path';
 import queryString = require('querystring');
-import { IRequestOptions, IRequestQueryParams } from './RestClient';
+import { IRequestOptions } from './RestClient';
+import { IRequestQueryParams } from './Interfaces';
 
 /**
  * creates an url from a request url and optional base url (http://server:8080)
@@ -41,7 +42,7 @@ export function getUrl(resource: string, baseUrl?: string, options?: IRequestOpt
         requestUrl = url.format(resultantUrl);
     }
 
-    const queryParams = ((options || {}).queryParameters) || undefined;
+    const queryParams: IRequestQueryParams = ((options || {}).queryParameters) || undefined;
 
     return queryParams ?
         prepareUrlWithQueryParams(requestUrl, queryParams):

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-rest-client",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9500,9 +9500,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
+      "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==",
       "dev": true
     },
     "query-string": {
@@ -10340,6 +10340,14 @@
         "tough-cookie": "~2.4.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "dev": true
+        }
       }
     },
     "require-directory": {

--- a/package.json
+++ b/package.json
@@ -34,9 +34,10 @@
     "@types/shelljs": "0.7.4",
     "mocha": "^3.5.3",
     "nock": "9.6.1",
+    "qs": "^6.9.1",
     "react-scripts": "1.1.5",
-    "shelljs": "0.7.6",
     "semver": "4.3.3",
+    "shelljs": "0.7.6",
     "typescript": "3.1.5"
   },
   "dependencies": {

--- a/test/tests/resttests.ts
+++ b/test/tests/resttests.ts
@@ -58,30 +58,28 @@ describe('Rest Tests', function () {
 
     it('gets a resource passing Query Parameters', async() => {
         this.timeout(3000);
-        const options: restm.IRequestOptions = { queryParameters: _options.queryParameters };
-        const response: restm.IRestResponse<HttpBinData> = await _rest.get<HttpBinData>('https://httpbin.org/get', options);
+        const response: restm.IRestResponse<HttpBinData> = await _rest.get<HttpBinData>('https://httpbin.org/get', _options);
 
         assert(response.statusCode == 200, "statusCode should be 200");
         assert(response.result.url === 'https://httpbin.org/get?id=1&type=compact');
-        Object.keys(options.queryParameters.params).forEach(key => {
+
+        Object.keys(_options.queryParameters.params).forEach(key => {
             const actual = response.result.args[key];
-            const expected = options.queryParameters.params[key];
+            const expected = _options.queryParameters.params[key];
 
             assert(expected == actual);
         })
     });
 
     it('gets a resource with baseUrl passing Query Parameters', async() => {
-        this.timeout(3000);
-        const options: restm.IRequestOptions = { queryParameters: _options.queryParameters };
-        const response: restm.IRestResponse<HttpBinData> = await _restBin.get<HttpBinData>('get', options);
+        const response: restm.IRestResponse<HttpBinData> = await _restBin.get<HttpBinData>('get', _options);
 
         assert(response.statusCode == 200, "statusCode should be 200");
         assert(response.result.url === 'https://httpbin.org/get?id=1&type=compact');
 
-        Object.keys(options.queryParameters.params).forEach(key => {
+        Object.keys(_options.queryParameters.params).forEach(key => {
             const actual = response.result.args[key];
-            const expected = options.queryParameters.params[key];
+            const expected = _options.queryParameters.params[key];
 
             assert(expected == actual);
         })

--- a/test/tests/resttests.ts
+++ b/test/tests/resttests.ts
@@ -17,10 +17,19 @@ export interface HttpBinData {
 describe('Rest Tests', function () {
     let _rest: restm.RestClient;
     let _restBin: restm.RestClient;
+    let _options: restm.IRequestOptions;
 
     before(() => {
         _rest = new restm.RestClient('typed-rest-client-tests');
         _restBin = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org');
+        _options = {
+            queryParameters: {
+                params: {
+                    id: 1,
+                    type: 'compact'
+                }
+            }
+        }
     });
 
     after(() => {
@@ -45,6 +54,37 @@ describe('Rest Tests', function () {
         let restRes: restm.IRestResponse<HttpBinData> = await _restBin.get<HttpBinData>('get');
         assert(restRes.statusCode == 200, "statusCode should be 200");
         assert(restRes.result && restRes.result.url === 'https://httpbin.org/get');
+    });
+
+    it('gets a resource passing Query Parameters', async() => {
+        this.timeout(3000);
+        const options: restm.IRequestOptions = { queryParameters: _options.queryParameters };
+        const response: restm.IRestResponse<HttpBinData> = await _rest.get<HttpBinData>('https://httpbin.org/get', options);
+
+        assert(response.statusCode == 200, "statusCode should be 200");
+        assert(response.result.url === 'https://httpbin.org/get?id=1&type=compact');
+        Object.keys(options.queryParameters.params).forEach(key => {
+            const actual = response.result.args[key];
+            const expected = options.queryParameters.params[key];
+
+            assert(expected == actual);
+        })
+    });
+
+    it('gets a resource with baseUrl passing Query Parameters', async() => {
+        this.timeout(3000);
+        const options: restm.IRequestOptions = { queryParameters: _options.queryParameters };
+        const response: restm.IRestResponse<HttpBinData> = await _restBin.get<HttpBinData>('get', options);
+
+        assert(response.statusCode == 200, "statusCode should be 200");
+        assert(response.result.url === 'https://httpbin.org/get?id=1&type=compact');
+
+        Object.keys(options.queryParameters.params).forEach(key => {
+            const actual = response.result.args[key];
+            const expected = options.queryParameters.params[key];
+
+            assert(expected == actual);
+        })
     });
 
     it('creates a resource', async() => {

--- a/test/units/resttests.ts
+++ b/test/units/resttests.ts
@@ -3,6 +3,7 @@
 
 import assert = require('assert');
 import nock = require('nock');
+import * as ifm from 'typed-rest-client/Interfaces';
 import * as restm from 'typed-rest-client/RestClient';
 import * as util from 'typed-rest-client/Util';
 
@@ -17,11 +18,18 @@ describe('Rest Tests', function () {
     let _rest: restm.RestClient;
     let _restBin: restm.RestClient;
     let _restMic: restm.RestClient;
+    let _queryParams: ifm.IRequestQueryParams;
 
     before(() => {
         _rest = new restm.RestClient('typed-rest-client-tests');
         _restBin = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org');
         _restMic = new restm.RestClient('typed-rest-client-tests', 'http://microsoft.com');
+        _queryParams = {
+            params: {
+                id: 1,
+                foo: 'bar'
+            }
+        };
     });
 
     after(() => {
@@ -475,6 +483,21 @@ describe('Rest Tests', function () {
         assert(res === 'http://microsoft.com', "should be http://microsoft.com");
     });
 
+    it('resolves a host resource with empty baseUrl and passing query parameters', async() => {
+        const res: string = util.getUrl('http://microsoft.com', '', _queryParams);
+        assert(res === 'http://microsoft.com?id=1&foo=bar', `should be http://microsoft.com?id=1&foo=bar but is ${res}`);
+    });
+
+    it('resolves an empty resource with baseUrl and passing query parameters', async() => {
+        const res: string = util.getUrl('', 'http://microsoft.com', _queryParams);
+        assert(res === 'http://microsoft.com?id=1&foo=bar', `should be http://microsoft.com?id=1&foo=bar but is ${res}`);
+    });
+
+    it('resolves a null resource with baseUrl and passing query parameters', async() => {
+        const res: string = util.getUrl(null, 'http://microsoft.com', _queryParams);
+        assert(res === 'http://microsoft.com?id=1&foo=bar', `should be http://microsoft.com?id=1&foo=bar but is ${res}`);
+    });
+
     it('resolves a full resource and no baseUrl', async() => {
         let res: string = util.getUrl('http://microsoft.com/get?x=y&a=b');
         assert(res === 'http://microsoft.com/get?x=y&a=b', `should be http://microsoft.com/get?x=y&a=b but is ${res}`);
@@ -488,6 +511,16 @@ describe('Rest Tests', function () {
     it('resolves a relative path resource with host baseUrl', async() => {
         let res: string = util.getUrl('get/foo', 'http://microsoft.com');
         assert(res === 'http://microsoft.com/get/foo', `should be http://microsoft.com/get/foo but is ${res}`);
+    });
+
+    it('resolves a rooted path resource with host baseUrl and passing query parameters', async() => {
+        const res: string = util.getUrl('/get/foo', 'http://microsoft.com', _queryParams);
+        assert(res === 'http://microsoft.com/get/foo?id=1&foo=bar', `should be http://microsoft.com/get/foo?id=1&foo=bar but is ${res}`)
+    });
+
+    it('resolves a relative path resource with host baseUrl and passing query parameters', async() => {
+        const res: string = util.getUrl('get/foo', 'http://microsoft.com', _queryParams);
+        assert(res === 'http://microsoft.com/get/foo?id=1&foo=bar', `should be http://microsoft.com/get/foo?id=1&foo=bar but is ${res}`);
     });
 
     it('resolves a rooted path resource with pathed baseUrl', async() => {


### PR DESCRIPTION
** Description **:
Per Issue #172 reported, this PR will allow sending query-parameters with RestClient GET Requests.

**Introduced Changes**:
- Introduced a new common interface IRequestQueryParams, which can be globally used by any contributors willing to benefit from it OR build upon it after this contribution.
```
interface IRequestQueryParams {
    options?: {
        separator?: string,
        arrayFormat?: string,
        shouldAllowDots?: boolean
        shouldOnlyEncodeValues?: boolean,
    },
    params: {
        [name: string]: string | number | (string | number)[]
    }
}
```
- function **getUrl** of Util.ts to receive _optional_ query parameters object, to use while building the request's URL: `getUrl(resource: string, baseUrl?: string, queryParams?: IRequestQueryParams)`.

- Modified the `RestClient.ts` module so that the `IRequestOptions` interface now can have optional **queryParameters** field of `IRequestQueryParams` type.

- Added integration tests to address the change
- Added unit tests to address changes