### PR TITLE
fix: Add if-else block before Resolving the Promise in HttpClient's readBody() function

### DIFF
--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -68,10 +68,11 @@ export class HttpClientResponse implements ifm.IHttpClientResponse {
             }).on('end', async function() {
                 if (isGzippedEncoded) { // Process GZipped Response Body HERE
                     const gunzippedBody = await util.decompressGzippedContent(buffer, encodingCharset);
-                    resolve(gunzippedBody);
-                }
 
-                resolve(buffer.toString(encodingCharset));
+                    resolve(gunzippedBody);
+                } else {
+                    resolve(buffer.toString(encodingCharset));
+                }
             }).on('error', function(err) {
                 reject(err);
             });

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -10,23 +10,6 @@
         "qs": "^6.9.1",
         "tunnel": "0.0.4",
         "underscore": "1.8.3"
-      },
-      "dependencies": {
-        "qs": {
-          "version": "6.9.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
-          "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
-        },
-        "tunnel": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
-          "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
-        },
-        "underscore": {
-          "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-        }
       }
     }
   }

--- a/test/tests/httptests.ts
+++ b/test/tests/httptests.ts
@@ -43,7 +43,7 @@ describe('Http Tests', function () {
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody();      
         let obj: any = JSON.parse(body);
-        assert(obj.url === "https://httpbin.org/get");
+        assert(obj.url === "http://httpbin.org/get");
         assert('User-Agent' in obj.headers === true, "User-Agent should be set");
     });
 
@@ -53,7 +53,7 @@ describe('Http Tests', function () {
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody();      
         let obj: any = JSON.parse(body);
-        assert(obj.url === "https://httpbin.org/get");
+        assert(obj.url === "http://httpbin.org/get");
         assert('User-Agent' in obj.headers === false, "User-Agent should not be set");
     });
 
@@ -63,7 +63,7 @@ describe('Http Tests', function () {
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody();      
         let obj: any = JSON.parse(body);
-        assert(obj.url === "https://httpbin.org/get");
+        assert(obj.url === "http://httpbin.org/get");
         assert('User-Agent' in obj.headers === false, "User-Agent should not be set");
     });
 
@@ -73,7 +73,7 @@ describe('Http Tests', function () {
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody();      
         let obj: any = JSON.parse(body);
-        assert(obj.url === "https://httpbin.org/get");
+        assert(obj.url === "http://httpbin.org/get");
         assert('User-Agent' in obj.headers === true, "User-Agent should be set");
         assert(obj.headers['User-Agent'] === '', "User-Agent should be set to empty string");
     });
@@ -114,7 +114,7 @@ describe('Http Tests', function () {
         let auth: string = obj.headers.Authorization;
         let creds: string = Buffer.from(auth.substring('Basic '.length), 'base64').toString();
         assert(creds === 'johndoe:password', "should be the username and password");
-        assert(obj.url === "https://httpbin.org/get");
+        assert(obj.url === "http://httpbin.org/get");
     });
     
     it('does basic http get request with pat token auth', async() => {
@@ -129,7 +129,7 @@ describe('Http Tests', function () {
         let auth: string = obj.headers.Authorization;
         let creds: string = Buffer.from(auth.substring('Basic '.length), 'base64').toString();
         assert(creds === 'PAT:' + token, "creds should be the token");
-        assert(obj.url === "https://httpbin.org/get");
+        assert(obj.url === "http://httpbin.org/get");
     });
     
     it('does basic http get request with default headers', async() => {
@@ -145,7 +145,7 @@ describe('Http Tests', function () {
         let obj:any = JSON.parse(body);
         assert(obj.headers.Accept === 'application/json', "Accept header should be 'application/json'");
         assert(obj.headers['Content-Type'] === 'application/json', "Content-Type header should be 'application/json'");
-        assert(obj.url === "https://httpbin.org/get");
+        assert(obj.url === "http://httpbin.org/get");
     });
     
     it('does basic http get request with merged headers', async() => {
@@ -163,7 +163,7 @@ describe('Http Tests', function () {
         let obj:any = JSON.parse(body);
         assert(obj.headers.Accept === 'application/json', "Accept header should be 'application/json'");
         assert(obj.headers['Content-Type'] === 'application/x-www-form-urlencoded', "Content-Type header should be 'application/x-www-form-urlencoded'");
-        assert(obj.url === "https://httpbin.org/get");
+        assert(obj.url === "http://httpbin.org/get");
     });
 
     it('pipes a get request', () => {
@@ -226,7 +226,7 @@ describe('Http Tests', function () {
         let body: string = await res.readBody();
         let obj:any = JSON.parse(body);
         assert(obj.data === b);
-        assert(obj.url === "https://httpbin.org/post");
+        assert(obj.url === "http://httpbin.org/post");
     });
     
     it('does basic http patch request', async() => {
@@ -236,7 +236,7 @@ describe('Http Tests', function () {
         let body: string = await res.readBody();
         let obj:any = JSON.parse(body);
         assert(obj.data === b);
-        assert(obj.url === "https://httpbin.org/patch");
+        assert(obj.url === "http://httpbin.org/patch");
     });
     
     it('does basic http options request', async() => {
@@ -267,7 +267,7 @@ describe('Http Tests with keepAlive', function () {
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody();      
         let obj:any = JSON.parse(body);
-        assert(obj.url === "https://httpbin.org/get");
+        assert(obj.url === "http://httpbin.org/get");
     });
 
     it('does basic head request with keepAlive true', async() => {
@@ -289,7 +289,7 @@ describe('Http Tests with keepAlive', function () {
         let body: string = await res.readBody();
         let obj:any = JSON.parse(body);
         assert(obj.data === b);
-        assert(obj.url === "https://httpbin.org/post");
+        assert(obj.url === "http://httpbin.org/post");
     });
     
     it('does basic http patch request with keepAlive true', async() => {
@@ -299,7 +299,7 @@ describe('Http Tests with keepAlive', function () {
         let body: string = await res.readBody();
         let obj:any = JSON.parse(body);
         assert(obj.data === b);
-        assert(obj.url === "https://httpbin.org/patch");
+        assert(obj.url === "http://httpbin.org/patch");
     }); 
     
     it('does basic http options request with keepAlive true', async() => {


### PR DESCRIPTION
- This PR fixes a bug where the `readBody()` function which returns a **Promise** has two consecutive `resolve()` of which both gets called.
- An `if-else` block is added to resolve the Promise only **once**.