### PR TITLE
Disable authentications on redirections

### DIFF
--- a/lib/handlers/basiccreds.ts
+++ b/lib/handlers/basiccreds.ts
@@ -6,20 +6,24 @@ import ifm = require('../Interfaces');
 export class BasicCredentialHandler implements ifm.IRequestHandler {
     username: string;
     password: string;
-    host: string;
+    allowCrossOriginAuthentication: boolean;
+    origin: string;
 
-    constructor(username: string, password: string) {
+    constructor(username: string, password: string, allowCrossOriginAuthentication?: boolean) {
         this.username = username;
         this.password = password;
+        this.allowCrossOriginAuthentication = allowCrossOriginAuthentication;
     }
 
     // currently implements pre-authorization
     // TODO: support preAuth = false where it hooks on 401
     prepareRequest(options:any): void {
+        if (!this.origin) {
+            this.origin = options.host;
+        }
         // If this is a redirection, don't set the Authorization header
-        if (!this.host || this.host === options.host) {
+        if (this.origin === options.host || this.allowCrossOriginAuthentication) {
             options.headers['Authorization'] = `Basic ${Buffer.from(`${this.username}:${this.password}`).toString('base64')}`;
-            this.host = options.host;
         }
         options.headers['X-TFS-FedAuthRedirect'] = 'Suppress';
     }

--- a/lib/handlers/basiccreds.ts
+++ b/lib/handlers/basiccreds.ts
@@ -6,6 +6,7 @@ import ifm = require('../Interfaces');
 export class BasicCredentialHandler implements ifm.IRequestHandler {
     username: string;
     password: string;
+    host: string;
 
     constructor(username: string, password: string) {
         this.username = username;
@@ -15,7 +16,11 @@ export class BasicCredentialHandler implements ifm.IRequestHandler {
     // currently implements pre-authorization
     // TODO: support preAuth = false where it hooks on 401
     prepareRequest(options:any): void {
-        options.headers['Authorization'] = `Basic ${Buffer.from(`${this.username}:${this.password}`).toString('base64')}`;
+        // If this is a redirection, don't set the Authorization header
+        if (!this.host || this.host === options.host) {
+            options.headers['Authorization'] = `Basic ${Buffer.from(`${this.username}:${this.password}`).toString('base64')}`;
+            this.host = options.host;
+        }
         options.headers['X-TFS-FedAuthRedirect'] = 'Suppress';
     }
 

--- a/lib/handlers/bearertoken.ts
+++ b/lib/handlers/bearertoken.ts
@@ -5,6 +5,7 @@ import ifm = require('../Interfaces');
 
 export class BearerCredentialHandler implements ifm.IRequestHandler {
     token: string;
+    host: string;
 
     constructor(token: string) {
         this.token = token;
@@ -13,7 +14,11 @@ export class BearerCredentialHandler implements ifm.IRequestHandler {
     // currently implements pre-authorization
     // TODO: support preAuth = false where it hooks on 401
     prepareRequest(options:any): void {
-        options.headers['Authorization'] = `Bearer ${this.token}`;
+        // If this is a redirection, don't set the Authorization header
+        if (!this.host || this.host === options.host) {
+            options.headers['Authorization'] = `Bearer ${this.token}`;
+            this.host = options.host;
+        }
         options.headers['X-TFS-FedAuthRedirect'] = 'Suppress';
     }
 

--- a/lib/handlers/bearertoken.ts
+++ b/lib/handlers/bearertoken.ts
@@ -5,19 +5,23 @@ import ifm = require('../Interfaces');
 
 export class BearerCredentialHandler implements ifm.IRequestHandler {
     token: string;
-    host: string;
+    allowCrossOriginAuthentication: boolean;
+    origin: string;
 
-    constructor(token: string) {
+    constructor(token: string, allowCrossOriginAuthentication?: boolean) {
         this.token = token;
+        this.allowCrossOriginAuthentication = allowCrossOriginAuthentication;
     }
 
     // currently implements pre-authorization
     // TODO: support preAuth = false where it hooks on 401
     prepareRequest(options:any): void {
+        if (!this.origin) {
+            this.origin = options.host;
+        }
         // If this is a redirection, don't set the Authorization header
-        if (!this.host || this.host === options.host) {
+        if (this.origin === options.host || this.allowCrossOriginAuthentication) {
             options.headers['Authorization'] = `Bearer ${this.token}`;
-            this.host = options.host;
         }
         options.headers['X-TFS-FedAuthRedirect'] = 'Suppress';
     }

--- a/lib/handlers/personalaccesstoken.ts
+++ b/lib/handlers/personalaccesstoken.ts
@@ -5,6 +5,7 @@ import ifm = require('../Interfaces');
 
 export class PersonalAccessTokenCredentialHandler implements ifm.IRequestHandler {
     token: string;
+    host: string;
 
     constructor(token: string) {
         this.token = token;
@@ -13,7 +14,11 @@ export class PersonalAccessTokenCredentialHandler implements ifm.IRequestHandler
     // currently implements pre-authorization
     // TODO: support preAuth = false where it hooks on 401
     prepareRequest(options:any): void {
-        options.headers['Authorization'] = `Basic ${Buffer.from(`PAT:${this.token}`).toString('base64')}`;
+        // If this is a redirection, don't set the Authorization header
+        if (!this.host || this.host === options.host) {
+            options.headers['Authorization'] = `Basic ${Buffer.from(`PAT:${this.token}`).toString('base64')}`;
+            this.host = options.host;
+        }
         options.headers['X-TFS-FedAuthRedirect'] = 'Suppress';
     }
 

--- a/lib/handlers/personalaccesstoken.ts
+++ b/lib/handlers/personalaccesstoken.ts
@@ -5,19 +5,23 @@ import ifm = require('../Interfaces');
 
 export class PersonalAccessTokenCredentialHandler implements ifm.IRequestHandler {
     token: string;
-    host: string;
+    allowCrossOriginAuthentication: boolean;
+    origin: string;
 
-    constructor(token: string) {
+    constructor(token: string, allowCrossOriginAuthentication?: boolean) {
         this.token = token;
+        this.allowCrossOriginAuthentication = allowCrossOriginAuthentication;
     }
 
     // currently implements pre-authorization
     // TODO: support preAuth = false where it hooks on 401
     prepareRequest(options:any): void {
+        if (!this.origin) {
+            this.origin = options.host;
+        }
         // If this is a redirection, don't set the Authorization header
-        if (!this.host || this.host === options.host) {
+        if (this.origin === options.host || this.allowCrossOriginAuthentication) {
             options.headers['Authorization'] = `Basic ${Buffer.from(`PAT:${this.token}`).toString('base64')}`;
-            this.host = options.host;
         }
         options.headers['X-TFS-FedAuthRedirect'] = 'Suppress';
     }


### PR DESCRIPTION
This PR fixes a security issue.

**Current behavior**
1. Send any request with `BasicCredentialHandler`, `BearerCredentialHandler` or `PersonalAccessTokenCredentialHandler`.
2. The target host may return a redirection (3xx), with a link to a second host.
3. The next request will use the credentials to authenticate with the second host, by setting the `Authorization` header.

**Expected behavior**
3. The next request will NOT set the `Authorization` header.

See the same issue for CURL: 
1. [HTTP authentication leak in redirects](https://curl.haxx.se/docs/CVE-2018-1000007.html) - I used the same solution as CURL did.
2. [CVE-2018-1000007](https://nvd.nist.gov/vuln/detail/CVE-2018-1000007).
