### PR TITLE
Support adding query params for HTTP Delete

### DIFF
--- a/lib/RestClient.ts
+++ b/lib/RestClient.ts
@@ -87,7 +87,7 @@ export class RestClient {
     public async del<T>(resource: string,
         options?: IRequestOptions): Promise<IRestResponse<T>> {
 
-        let url: string = util.getUrl(resource, this._baseUrl);
+        let url: string = util.getUrl(resource, this._baseUrl, (options || {}).queryParameters);
         let res: httpm.HttpClientResponse = await this.client.del(url,
             this._headersFromOptions(options));
         return this.processResponse<T>(res, options);

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -14,15 +14,18 @@
       "dependencies": {
         "qs": {
           "version": "6.9.3",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
+          "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw=="
         },
         "tunnel": {
           "version": "0.0.6",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+          "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
         },
         "underscore": {
           "version": "1.8.3",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
         }
       }
     }

--- a/test/tests/resttests.ts
+++ b/test/tests/resttests.ts
@@ -147,6 +147,35 @@ describe('Rest Tests', function () {
         assert(restRes.result && restRes.result.url === 'https://httpbin.org/delete');
     });
 
+    it('deletes a resource passing Query Parameters', async () => {
+        this.timeout(3000);
+        const response: restm.IRestResponse<HttpBinData> = await _rest.del<HttpBinData>('https://httpbin.org/delete', _options);
+
+        assert(response.statusCode == 200, "statusCode should be 200");
+        assert(response.result.url === 'https://httpbin.org/delete?id=1&type=compact');
+
+        Object.keys(_options.queryParameters.params).forEach(key => {
+            const actual = response.result.args[key];
+            const expected = _options.queryParameters.params[key];
+
+            assert(expected == actual);
+        })
+    });
+
+    it('deletes a resource with baseUrl passing Query Parameters', async () => {
+        const response: restm.IRestResponse<HttpBinData> = await _restBin.del<HttpBinData>('delete', _options);
+
+        assert(response.statusCode == 200, "statusCode should be 200");
+        assert(response.result.url === 'https://httpbin.org/delete?id=1&type=compact');
+
+        Object.keys(_options.queryParameters.params).forEach(key => {
+            const actual = response.result.args[key];
+            const expected = _options.queryParameters.params[key];
+
+            assert(expected == actual);
+        })
+    });
+
     it('does an options request', async() => {
         let restRes: restm.IRestResponse<HttpBinData> = await _rest.options<HttpBinData>('https://httpbin.org');
         assert(restRes.statusCode == 200, "statusCode should be 200");


### PR DESCRIPTION
Thanks to @hamzahejja for #180 

I noticed that this was only supported for `GET` requests. It looks like the REST dissertation or HTTP spec don't really take a stance on query params in a `DELETE` requests so this does seem to be done in the wild (for example: https://developer.atlassian.com/cloud/jira/software/rest/#api-builds-0-1-bulkByProperties-delete).