### PR TITLE
Added retry handling when we have a network Error

### DIFF
--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -41,6 +41,7 @@ export enum HttpCodes {
 
 const HttpRedirectCodes: number[] = [HttpCodes.MovedPermanently, HttpCodes.ResourceMoved, HttpCodes.SeeOther, HttpCodes.TemporaryRedirect, HttpCodes.PermanentRedirect];
 const HttpResponseRetryCodes: number[] = [HttpCodes.BadGateway, HttpCodes.ServiceUnavailable, HttpCodes.GatewayTimeout];
+const NetworkRetryErrors: string[] = ['ECONNRESET', 'ENOTFOUND', 'ESOCKETTIMEDOUT', 'ETIMEDOUT', 'ECONNREFUSED'];
 const RetryableHttpVerbs: string[] = ['OPTIONS', 'GET', 'DELETE', 'HEAD'];
 const ExponentialBackoffCeiling = 10;
 const ExponentialBackoffTimeSlice = 5;
@@ -243,8 +244,15 @@ export class HttpClient implements ifm.IHttpClient {
 
         let response: HttpClientResponse;
         while (numTries < maxTries) {
-            response = await this.requestRaw(info, data);
-
+            try{
+                response = await this.requestRaw(info, data);
+            }
+            catch (err) {
+                if(err && err.code && NetworkRetryErrors.indexOf(err.code) !== 1){
+                    continue
+                }
+                throw err;
+            }
             // Check if it's an authentication challenge
             if (response && response.message && response.message.statusCode === HttpCodes.Unauthorized) {
                 let authenticationHandler: ifm.IRequestHandler;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "samples": "node make.js samples",
     "units": "node make.js units",
     "validate": "node make.js validate",
-    "postinstall": "build"
+    "postinstall": "npm build"
   
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "bt": "node make.js buildtest",
     "samples": "node make.js samples",
     "units": "node make.js units",
-    "validate": "node make.js validate"
+    "validate": "node make.js validate",
+    "postinstall": "build"
+  
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-rest-client",
-  "version": "1.7.3",
+  "version": "1.8.3",
   "description": "Node Rest and Http Clients for use with TypeScript",
   "main": "./RestClient.js",
   "scripts": {


### PR DESCRIPTION
On any http/https library request error we reject the promise in requestRaw. 

There might be a TCP network error which has occurred which we will want to retry.

I have selected the following errors to be retryable : 'ECONNRESET', 'ENOTFOUND', 'ESOCKETTIMEDOUT', 'ETIMEDOUT', 'ECONNREFUSED'