### PR TITLE
Added handling for when we have network failures in the retry mechanism

### DIFF
--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -248,7 +248,7 @@ export class HttpClient implements ifm.IHttpClient {
                 response = await this.requestRaw(info, data);
             }
             catch (err) {
-                if(err && err.code && NetworkRetryErrors.indexOf(err.code) !== 1){
+                if(err && err.code && NetworkRetryErrors.indexOf(err.code) > -1){
                     continue;
                 }
                 throw err;

--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -249,7 +249,7 @@ export class HttpClient implements ifm.IHttpClient {
             }
             catch (err) {
                 if(err && err.code && NetworkRetryErrors.indexOf(err.code) !== 1){
-                    continue
+                    continue;
                 }
                 throw err;
             }

--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -41,6 +41,7 @@ export enum HttpCodes {
 
 const HttpRedirectCodes: number[] = [HttpCodes.MovedPermanently, HttpCodes.ResourceMoved, HttpCodes.SeeOther, HttpCodes.TemporaryRedirect, HttpCodes.PermanentRedirect];
 const HttpResponseRetryCodes: number[] = [HttpCodes.BadGateway, HttpCodes.ServiceUnavailable, HttpCodes.GatewayTimeout];
+const NetworkRetryErrors: string[] = ['ECONNRESET', 'ENOTFOUND', 'ESOCKETTIMEDOUT', 'ETIMEDOUT', 'ECONNREFUSED'];
 const RetryableHttpVerbs: string[] = ['OPTIONS', 'GET', 'DELETE', 'HEAD'];
 const ExponentialBackoffCeiling = 10;
 const ExponentialBackoffTimeSlice = 5;
@@ -243,8 +244,15 @@ export class HttpClient implements ifm.IHttpClient {
 
         let response: HttpClientResponse;
         while (numTries < maxTries) {
-            response = await this.requestRaw(info, data);
-
+            try{
+                response = await this.requestRaw(info, data);
+            }
+            catch (err) {
+                if(err && err.code && NetworkRetryErrors.indexOf(err.code) !== 1){
+                    continue
+                }
+                throw err;
+            }
             // Check if it's an authentication challenge
             if (response && response.message && response.message.statusCode === HttpCodes.Unauthorized) {
                 let authenticationHandler: ifm.IRequestHandler;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-rest-client",
-  "version": "1.7.3",
+  "version": "1.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-rest-client",
-  "version": "1.8.3",
+  "version": "1.8.0",
   "description": "Node Rest and Http Clients for use with TypeScript",
   "main": "./RestClient.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-rest-client",
-  "version": "1.7.3",
+  "version": "1.8.3",
   "description": "Node Rest and Http Clients for use with TypeScript",
   "main": "./RestClient.js",
   "scripts": {


### PR DESCRIPTION
This will add handling when we have a network failure.
Occurs when the ADO Connection itself goes down and not return any status code.

The following network errors will be retried `'ECONNRESET', 'ENOTFOUND', 'ESOCKETTIMEDOUT', 'ETIMEDOUT', 'ECONNREFUSED'`