### PR TITLE
Add support for query parameters for POST, PATCH, and PUT requests

### DIFF
--- a/lib/RestClient.ts
+++ b/lib/RestClient.ts
@@ -104,7 +104,7 @@ export class RestClient {
         resources: any,
         options?: IRequestOptions): Promise<IRestResponse<T>> {
 
-        let url: string = util.getUrl(resource, this._baseUrl);
+        let url: string = util.getUrl(resource, this._baseUrl, (options || {}).queryParameters);
         let headers: ifm.IHeaders = this._headersFromOptions(options, true);
 
         let data: string = JSON.stringify(resources, null, 2);
@@ -123,7 +123,7 @@ export class RestClient {
         resources: any,
         options?: IRequestOptions): Promise<IRestResponse<T>> {
 
-        let url: string = util.getUrl(resource, this._baseUrl);
+        let url: string = util.getUrl(resource, this._baseUrl, (options || {}).queryParameters);
         let headers: ifm.IHeaders = this._headersFromOptions(options, true);
 
         let data: string = JSON.stringify(resources, null, 2);
@@ -142,7 +142,7 @@ export class RestClient {
         resources: any,
         options?: IRequestOptions): Promise<IRestResponse<T>> {
 
-        let url: string = util.getUrl(resource, this._baseUrl);
+        let url: string = util.getUrl(resource, this._baseUrl, (options || {}).queryParameters);
         let headers: ifm.IHeaders = this._headersFromOptions(options, true);
 
         let data: string = JSON.stringify(resources, null, 2);

--- a/test/tests/resttests.ts
+++ b/test/tests/resttests.ts
@@ -101,6 +101,35 @@ describe('Rest Tests', function () {
         assert(restRes.result && restRes.result.json.name === 'foo');
     });
 
+    it('creates a resource passing Query Parameters', async () => {
+        this.timeout(3000);
+        const response: restm.IRestResponse<HttpBinData> = await _rest.create<HttpBinData>('https://httpbin.org/post', _options);
+
+        assert(response.statusCode == 200, "statusCode should be 200");
+        assert(response.result.url === 'https://httpbin.org/post?id=1&type=compact');
+
+        Object.keys(_options.queryParameters.params).forEach(key => {
+            const actual = response.result.args[key];
+            const expected = _options.queryParameters.params[key];
+
+            assert(expected == actual);
+        })
+    });
+
+    it('creates a resource with baseUrl passing Query Parameters', async () => {
+        const response: restm.IRestResponse<HttpBinData> = await _restBin.create<HttpBinData>('post', _options);
+
+        assert(response.statusCode == 200, "statusCode should be 200");
+        assert(response.result.url === 'https://httpbin.org/post?id=1&type=compact');
+
+        Object.keys(_options.queryParameters.params).forEach(key => {
+            const actual = response.result.args[key];
+            const expected = _options.queryParameters.params[key];
+
+            assert(expected == actual);
+        })
+    });
+
     it('replaces a resource', async() => {
         this.timeout(3000);
 
@@ -119,6 +148,35 @@ describe('Rest Tests', function () {
         assert(restRes.result && restRes.result.json.name === 'foo');
     });
 
+    it('puts a resource passing Query Parameters', async () => {
+        this.timeout(3000);
+        const response: restm.IRestResponse<HttpBinData> = await _rest.replace<HttpBinData>('https://httpbin.org/put', _options);
+
+        assert(response.statusCode == 200, "statusCode should be 200");
+        assert(response.result.url === 'https://httpbin.org/put?id=1&type=compact');
+
+        Object.keys(_options.queryParameters.params).forEach(key => {
+            const actual = response.result.args[key];
+            const expected = _options.queryParameters.params[key];
+
+            assert(expected == actual);
+        })
+    });
+
+    it('puts a resource with baseUrl passing Query Parameters', async () => {
+        const response: restm.IRestResponse<HttpBinData> = await _restBin.replace<HttpBinData>('put', _options);
+
+        assert(response.statusCode == 200, "statusCode should be 200");
+        assert(response.result.url === 'https://httpbin.org/put?id=1&type=compact');
+
+        Object.keys(_options.queryParameters.params).forEach(key => {
+            const actual = response.result.args[key];
+            const expected = _options.queryParameters.params[key];
+
+            assert(expected == actual);
+        })
+    });
+
     it('updates a resource', async() => {
         let res: any = { name: 'foo' };
         let restRes: restm.IRestResponse<HttpBinData> = await _rest.update<HttpBinData>('https://httpbin.org/patch', res);
@@ -133,6 +191,35 @@ describe('Rest Tests', function () {
         assert(restRes.statusCode == 200, "statusCode should be 200");
         assert(restRes.result && restRes.result.url === 'https://httpbin.org/patch');
         assert(restRes.result && restRes.result.json.name === 'foo');
+    });
+
+    it('updates a resource passing Query Parameters', async () => {
+        this.timeout(3000);
+        const response: restm.IRestResponse<HttpBinData> = await _rest.update<HttpBinData>('https://httpbin.org/patch', _options);
+
+        assert(response.statusCode == 200, "statusCode should be 200");
+        assert(response.result.url === 'https://httpbin.org/patch?id=1&type=compact');
+
+        Object.keys(_options.queryParameters.params).forEach(key => {
+            const actual = response.result.args[key];
+            const expected = _options.queryParameters.params[key];
+
+            assert(expected == actual);
+        })
+    });
+
+    it('updates a resource with baseUrl passing Query Parameters', async () => {
+        const response: restm.IRestResponse<HttpBinData> = await _restBin.update<HttpBinData>('patch', _options);
+
+        assert(response.statusCode == 200, "statusCode should be 200");
+        assert(response.result.url === 'https://httpbin.org/patch?id=1&type=compact');
+
+        Object.keys(_options.queryParameters.params).forEach(key => {
+            const actual = response.result.args[key];
+            const expected = _options.queryParameters.params[key];
+
+            assert(expected == actual);
+        })
     });
 
     it('deletes a resource', async() => {

--- a/test/tests/resttests.ts
+++ b/test/tests/resttests.ts
@@ -101,34 +101,35 @@ describe('Rest Tests', function () {
         assert(restRes.result && restRes.result.json.name === 'foo');
     });
 
-    it('creates a resource passing Query Parameters', async () => {
-        this.timeout(3000);
-        const response: restm.IRestResponse<HttpBinData> = await _rest.create<HttpBinData>('https://httpbin.org/post', _options);
+   it('creates a resource passing Query Parameters', async () => {
+		let res: any = { name: 'foo' };
+		let restRes: restm.IRestResponse<HttpBinData> = await _rest.create<HttpBinData>('https://httpbin.org/post', res, _options);
+		assert(restRes.statusCode == 200, "statusCode should be 200");
+		assert(restRes.result.url === 'https://httpbin.org/post?id=1&type=compact');
+		assert(restRes.result && restRes.result.json.name === 'foo');
 
-        assert(response.statusCode == 200, "statusCode should be 200");
-        assert(response.result.url === 'https://httpbin.org/post?id=1&type=compact');
+		Object.keys(_options.queryParameters.params).forEach(key => {
+			const actual = restRes.result.args[key];
+			const expected = _options.queryParameters.params[key];
 
-        Object.keys(_options.queryParameters.params).forEach(key => {
-            const actual = response.result.args[key];
-            const expected = _options.queryParameters.params[key];
+			assert(expected == actual);
+		})
+	});
 
-            assert(expected == actual);
-        })
-    });
+	it('creates a resource with baseUrl passing Query Parameters', async () => {
+		let res: any = { name: 'foo' };
+		let restRes: restm.IRestResponse<HttpBinData> = await _restBin.create<HttpBinData>('post', res, _options);
+		assert(restRes.statusCode == 200, "statusCode should be 200");
+		assert(restRes.result && restRes.result.url === 'https://httpbin.org/post?id=1&type=compact');
+		assert(restRes.result && restRes.result.json.name === 'foo');
 
-    it('creates a resource with baseUrl passing Query Parameters', async () => {
-        const response: restm.IRestResponse<HttpBinData> = await _restBin.create<HttpBinData>('post', _options);
+		Object.keys(_options.queryParameters.params).forEach(key => {
+			const actual = restRes.result.args[key];
+			const expected = _options.queryParameters.params[key];
 
-        assert(response.statusCode == 200, "statusCode should be 200");
-        assert(response.result.url === 'https://httpbin.org/post?id=1&type=compact');
-
-        Object.keys(_options.queryParameters.params).forEach(key => {
-            const actual = response.result.args[key];
-            const expected = _options.queryParameters.params[key];
-
-            assert(expected == actual);
-        })
-    });
+			assert(expected == actual);
+		})
+	});
 
     it('replaces a resource', async() => {
         this.timeout(3000);
@@ -148,34 +149,39 @@ describe('Rest Tests', function () {
         assert(restRes.result && restRes.result.json.name === 'foo');
     });
 
-    it('puts a resource passing Query Parameters', async () => {
-        this.timeout(3000);
-        const response: restm.IRestResponse<HttpBinData> = await _rest.replace<HttpBinData>('https://httpbin.org/put', _options);
+   it('puts a resource passing Query Parameters', async () => {
+		this.timeout(3000);
 
-        assert(response.statusCode == 200, "statusCode should be 200");
-        assert(response.result.url === 'https://httpbin.org/put?id=1&type=compact');
+		let res: any = { name: 'foo' };
+		let restRes: restm.IRestResponse<HttpBinData> = await _rest.replace<HttpBinData>('https://httpbin.org/put', res, _options);
+		assert(restRes.statusCode == 200, "statusCode should be 200");
+		assert(restRes.result && restRes.result.url === 'https://httpbin.org/put?id=1&type=compact');
+		assert(restRes.result && restRes.result.json.name === 'foo');
 
-        Object.keys(_options.queryParameters.params).forEach(key => {
-            const actual = response.result.args[key];
-            const expected = _options.queryParameters.params[key];
+		Object.keys(_options.queryParameters.params).forEach(key => {
+			const actual = restRes.result.args[key];
+			const expected = _options.queryParameters.params[key];
 
-            assert(expected == actual);
-        })
-    });
+			assert(expected == actual);
+		})
+	});
 
-    it('puts a resource with baseUrl passing Query Parameters', async () => {
-        const response: restm.IRestResponse<HttpBinData> = await _restBin.replace<HttpBinData>('put', _options);
+	it('puts a resource with baseUrl passing Query Parameters', async () => {
+		this.timeout(3000);
 
-        assert(response.statusCode == 200, "statusCode should be 200");
-        assert(response.result.url === 'https://httpbin.org/put?id=1&type=compact');
+		let res: any = { name: 'foo' };
+		let restRes: restm.IRestResponse<HttpBinData> = await _restBin.replace<HttpBinData>('put', res, _options);
+		assert(restRes.statusCode == 200, "statusCode should be 200");
+		assert(restRes.result && restRes.result.url === 'https://httpbin.org/put?id=1&type=compact');
+		assert(restRes.result && restRes.result.json.name === 'foo');
 
-        Object.keys(_options.queryParameters.params).forEach(key => {
-            const actual = response.result.args[key];
-            const expected = _options.queryParameters.params[key];
+		Object.keys(_options.queryParameters.params).forEach(key => {
+			const actual = restRes.result.args[key];
+			const expected = _options.queryParameters.params[key];
 
-            assert(expected == actual);
-        })
-    });
+			assert(expected == actual);
+		})
+	});
 
     it('updates a resource', async() => {
         let res: any = { name: 'foo' };
@@ -193,34 +199,35 @@ describe('Rest Tests', function () {
         assert(restRes.result && restRes.result.json.name === 'foo');
     });
 
-    it('updates a resource passing Query Parameters', async () => {
-        this.timeout(3000);
-        const response: restm.IRestResponse<HttpBinData> = await _rest.update<HttpBinData>('https://httpbin.org/patch', _options);
+   it('updates a resource passing Query Parameters', async () => {
+		let res: any = { name: 'foo' };
+		let restRes: restm.IRestResponse<HttpBinData> = await _rest.update<HttpBinData>('https://httpbin.org/patch', res, _options);
+		assert(restRes.statusCode == 200, "statusCode should be 200");
+		assert(restRes.result && restRes.result.url === 'https://httpbin.org/patch?id=1&type=compact');
+		assert(restRes.result && restRes.result.json.name === 'foo');
 
-        assert(response.statusCode == 200, "statusCode should be 200");
-        assert(response.result.url === 'https://httpbin.org/patch?id=1&type=compact');
+		Object.keys(_options.queryParameters.params).forEach(key => {
+			const actual = restRes.result.args[key];
+			const expected = _options.queryParameters.params[key];
 
-        Object.keys(_options.queryParameters.params).forEach(key => {
-            const actual = response.result.args[key];
-            const expected = _options.queryParameters.params[key];
+			assert(expected == actual);
+		})
+	});
 
-            assert(expected == actual);
-        })
-    });
+	it('updates a resource with baseUrl passing Query Parameters', async () => {
+		let res: any = { name: 'foo' };
+		let restRes: restm.IRestResponse<HttpBinData> = await _restBin.update<HttpBinData>('patch', res, _options);
+		assert(restRes.statusCode == 200, "statusCode should be 200");
+		assert(restRes.result && restRes.result.url === 'https://httpbin.org/patch?id=1&type=compact');
+		assert(restRes.result && restRes.result.json.name === 'foo');
 
-    it('updates a resource with baseUrl passing Query Parameters', async () => {
-        const response: restm.IRestResponse<HttpBinData> = await _restBin.update<HttpBinData>('patch', _options);
+		Object.keys(_options.queryParameters.params).forEach(key => {
+			const actual = restRes.result.args[key];
+			const expected = _options.queryParameters.params[key];
 
-        assert(response.statusCode == 200, "statusCode should be 200");
-        assert(response.result.url === 'https://httpbin.org/patch?id=1&type=compact');
-
-        Object.keys(_options.queryParameters.params).forEach(key => {
-            const actual = response.result.args[key];
-            const expected = _options.queryParameters.params[key];
-
-            assert(expected == actual);
-        })
-    });
+			assert(expected == actual);
+		})
+	});
 
     it('deletes a resource', async() => {
         let restRes: restm.IRestResponse<HttpBinData> = await _rest.del<HttpBinData>('https://httpbin.org/delete');


### PR DESCRIPTION
I noticed that this was only supported for GET and DELETE requests. Given that some APIs do actually support having query parameters for these types, I figured that adding support for them, given that it doesn't conflict with normal operation only makes the client more versatile