### PR TITLE
Handle possibility of relative redirect URLs

### DIFF
--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -286,7 +286,7 @@ export class HttpClient implements ifm.IHttpClient {
                     // if there's no location to redirect to, we won't
                     break;
                 }
-                let parsedRedirectUrl = url.parse(redirectUrl);
+                let parsedRedirectUrl = new URL(redirectUrl, requestUrl);
                 if (parsedUrl.protocol == 'https:' && parsedUrl.protocol != parsedRedirectUrl.protocol && !this._allowRedirectDowngrade) {
                     throw new Error("Redirect from HTTPS to HTTP protocol. This downgrade is not allowed for security reasons. If you want to allow this behavior, set the allowRedirectDowngrade option to true.");
                 }


### PR DESCRIPTION
Fixing issue mentioned in https://github.com/microsoft/typed-rest-client/issues/201

Using the `new URL` constructor handles all cases correctly:

```
new URL('/relative', 'https://localhost:80/');
new URL('/relative', 'https://localhost:80/api);
new URL('https://localhost:80/relative', 'https://localhost:80/api);

// all become https://localhost:80/relative
```