### PR TITLE
Bump package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-rest-client",
-  "version": "1.8.4",
+  "version": "1.8.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-rest-client",
-  "version": "1.8.4",
+  "version": "1.8.6",
   "description": "Node Rest and Http Clients for use with TypeScript",
   "main": "./RestClient.js",
   "scripts": {


### PR DESCRIPTION
We need to bump the package version to 1.8.6 to publish typed-rest-client with this revert [PR](https://github.com/microsoft/typed-rest-client/pull/292). After that, not deprecated version of the lib will be marked as the latest.