### PR TITLE
Add node 6, 10 and 14 to GitHub Actions and Azure Pipeline tests

### DIFF
--- a/.github/workflows/all-tests.yaml
+++ b/.github/workflows/all-tests.yaml
@@ -12,7 +12,7 @@ jobs:
     name: ${{ matrix.os}}-node${{ matrix.node}}
     strategy:
       matrix:
-        node: [8, 10, 12]
+        node: [6, 8, 10, 12, 14]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/all-tests.yaml
+++ b/.github/workflows/all-tests.yaml
@@ -12,7 +12,7 @@ jobs:
     name: ${{ matrix.os}}-node${{ matrix.node}}
     strategy:
       matrix:
-        node: [6, 8, 10, 12, 14]
+        node: [8, 6, 10, 12, 14]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/all-tests.yaml
+++ b/.github/workflows/all-tests.yaml
@@ -12,7 +12,7 @@ jobs:
     name: ${{ matrix.os}}-node${{ matrix.node}}
     strategy:
       matrix:
-        node: [6, 8, 10, 12, 14]
+        node: [8, 10, 12, 14]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/all-tests.yaml
+++ b/.github/workflows/all-tests.yaml
@@ -12,7 +12,7 @@ jobs:
     name: ${{ matrix.os}}-node${{ matrix.node}}
     strategy:
       matrix:
-        node: [8, 10, 12, 14]
+        node: [6, 8, 10, 12, 14]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/all-tests.yaml
+++ b/.github/workflows/all-tests.yaml
@@ -12,7 +12,7 @@ jobs:
     name: ${{ matrix.os}}-node${{ matrix.node}}
     strategy:
       matrix:
-        node: [8, 6, 10, 12, 14]
+        node: [6, 8, 10, 12, 14]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,24 @@ steps:
 - script: npm run units
   displayName: npm run units
 
+# test using node 10.24.1
+- task: NodeTool@0
+  inputs:
+    versionSpec: "10.24.1"
+  displayName: Install node 10.24.1
+
+- script: npm run units
+  displayName: npm run units
+
+# test using node 14.17.6
+- task: NodeTool@0
+  inputs:
+    versionSpec: "14.17.6"
+  displayName: Install node 14.17.6
+
+- script: npm run units
+  displayName: npm run units
+
 # publish build artifacts to drop folder so we can use them for release
 - task: PublishBuildArtifacts@1
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,11 +9,10 @@ strategy:
     'Node 14': 
       versionSpec: '14.x'
 steps:
-# use node 8.9.1 this is the recommended version for building the typed rest client
 - task: NodeTool@0
   inputs:
     versionSpec: $(versionSpec)
-  displayName: Install node 8.9.1
+  displayName: Install node
 
 # install dependencies
 - script: npm install

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,7 @@
 strategy:
   matrix:
+    'Node 6': 
+      versionSpec: '6.x'
     'Node 8': 
       versionSpec: '8.x'
     'Node 10': 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,8 +1,18 @@
+strategy:
+  matrix:
+    'Node 8': 
+      versionSpec: '8.x'
+    'Node 10': 
+      versionSpec: '10.x'
+    'Node 12': 
+      versionSpec: '12.x'
+    'Node 14': 
+      versionSpec: '14.x'
 steps:
 # use node 8.9.1 this is the recommended version for building the typed rest client
 - task: NodeTool@0
   inputs:
-    versionSpec: "8.9.1"
+    versionSpec: $(versionSpec)
   displayName: Install node 8.9.1
 
 # install dependencies
@@ -12,43 +22,6 @@ steps:
 # build
 - script: npm run build
   displayName: npm run build
-
-# test using node 8.9.1
-- script: npm run units
-  displayName: npm run units
-
-# test using node 4.8.6
-- task: NodeTool@0
-  inputs:
-    versionSpec: "4.8.6"
-  displayName: Install node 4.8.6
-
-- script: npm run units
-  displayName: npm run units
-
-# test using node 6.12.0
-- task: NodeTool@0
-  inputs:
-    versionSpec: "6.12.0"
-  displayName: Install node 6.12.0
-
-- script: npm run units
-  displayName: npm run units
-
-# test using node 10.24.1
-- task: NodeTool@0
-  inputs:
-    versionSpec: "10.24.1"
-  displayName: Install node 10.24.1
-
-- script: npm run units
-  displayName: npm run units
-
-# test using node 14.17.6
-- task: NodeTool@0
-  inputs:
-    versionSpec: "14.17.6"
-  displayName: Install node 14.17.6
 
 - script: npm run units
   displayName: npm run units

--- a/make.js
+++ b/make.js
@@ -26,7 +26,7 @@ var enforceMinimumVersions = function () {
 
     // enforce minimum npm version
     // NOTE: We are enforcing this version of npm because we use package-lock.json
-    var minimumNpmVersion = '5.5.1';
+    var minimumNpmVersion = '3.10.10';
     var currentNpmVersion = ncp.execSync('npm -v', { encoding: 'utf-8' });
     if (semver.lt(currentNpmVersion, minimumNpmVersion)) {
         fail('requires npm >= ' + minimumNpmVersion + '.  installed: ' + currentNpmVersion);


### PR DESCRIPTION
Add node 6, 10 and 14 to GitHub Actions and Azure Pipeline tests, lower npm requirements in make.js due to it being unable to use node 6