### PR TITLE
Fix broken azure pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,6 @@
+pool:
+  vmImage: ubuntu-20.04
+
 parameters:
   - name: versionSpec
     type: object

--- a/test/tests/httptests.ts
+++ b/test/tests/httptests.ts
@@ -9,8 +9,9 @@ import * as path from 'path';
 
 let sampleFilePath: string = path.join(__dirname, 'testoutput.txt');
 
-if (process.version.startsWith('v8')) {
-    console.log('Setting NODE_TLS_REJECT_UNAUTHORIZED = 0 to avoid certificate errors on node 8');
+const nodeVersionsWithCertificateErrors = [6, 8];
+if (nodeVersionsWithCertificateErrors.find((nodeVersion) => process.version.startsWith(`v${nodeVersion}.`))) {
+    console.log('Setting NODE_TLS_REJECT_UNAUTHORIZED = 0 to avoid certificate errors on this node version');
     process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 }
 

--- a/test/tests/httptests.ts
+++ b/test/tests/httptests.ts
@@ -9,6 +9,11 @@ import * as path from 'path';
 
 let sampleFilePath: string = path.join(__dirname, 'testoutput.txt');
 
+if (process.version.startsWith('v8')) {
+    console.log('Setting NODE_TLS_REJECT_UNAUTHORIZED = 0 to avoid certificate errors on node 8');
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+}
+
 describe('Http Tests', function () {
     let _http: httpm.HttpClient;
     let _httpbin: httpm.HttpClient;

--- a/test/tests/httptests.ts
+++ b/test/tests/httptests.ts
@@ -10,9 +10,10 @@ import * as path from 'path';
 let sampleFilePath: string = path.join(__dirname, 'testoutput.txt');
 
 const nodeVersionsWithCertificateErrors = [6, 8];
+let redirectProtocol = 'https';
 if (nodeVersionsWithCertificateErrors.find((nodeVersion) => process.version.startsWith(`v${nodeVersion}.`))) {
-    console.log('Setting NODE_TLS_REJECT_UNAUTHORIZED = 0 to avoid certificate errors on this node version');
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+    console.log('Using protocol HTTP for redirect tests to avoid certificate errors on this node version');
+    redirectProtocol = 'http';
 }
 
 describe('Http Tests', function () {
@@ -185,7 +186,7 @@ describe('Http Tests', function () {
     });
     
     it('does basic get request with redirects', async() => {
-        let res: httpm.HttpClientResponse = await _http.get("https://httpbingo.org/redirect-to?url=" + encodeURIComponent("https://httpbin.org/get"))
+        let res: httpm.HttpClientResponse = await _http.get(`${redirectProtocol}://httpbingo.org/redirect-to?url=` + encodeURIComponent("https://httpbin.org/get"))
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody();
         let obj:any = JSON.parse(body);
@@ -193,7 +194,7 @@ describe('Http Tests', function () {
     });
 
     it('does basic get request with redirects (303)', async() => {
-        let res: httpm.HttpClientResponse = await _http.get("https://httpbingo.org/redirect-to?url=" + encodeURIComponent("https://httpbin.org/get") + '&status_code=303')
+        let res: httpm.HttpClientResponse = await _http.get(`${redirectProtocol}://httpbingo.org/redirect-to?url=` + encodeURIComponent("https://httpbin.org/get") + '&status_code=303')
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody();
         let obj:any = JSON.parse(body);
@@ -201,14 +202,14 @@ describe('Http Tests', function () {
     });
 
     it('returns 404 for not found get request on redirect', async() => {
-        let res: httpm.HttpClientResponse = await _http.get("https://httpbingo.org/redirect-to?url=" + encodeURIComponent("https://httpbin.org/status/404") + '&status_code=303')
+        let res: httpm.HttpClientResponse = await _http.get(`${redirectProtocol}://httpbingo.org/redirect-to?url=` + encodeURIComponent("https://httpbin.org/status/404") + '&status_code=303')
         assert(res.message.statusCode == 404, "status code should be 404");
         let body: string = await res.readBody();
     });
 
     it('does not follow redirects if disabled', async() => {
         let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests', null, { allowRedirects: false });
-        let res: httpm.HttpClientResponse = await http.get("https://httpbingo.org/redirect-to?url=" + encodeURIComponent("https://httpbin.org/get"))
+        let res: httpm.HttpClientResponse = await http.get(`${redirectProtocol}://httpbingo.org/redirect-to?url=` + encodeURIComponent("https://httpbin.org/get"))
         assert(res.message.statusCode == 302, "status code should be 302");
         let body: string = await res.readBody();
     });


### PR DESCRIPTION
Currently the pipeline is not working because the default image is assumed to be ubuntu-16, which is removed.
This PR changes the image to ubuntu-20
Also, this introduces a temporary fix for [node 6 / node 8 certificate issue](https://stackoverflow.com/questions/62128611/nodejs-certificate-has-expired) in unit tests.