### PR TITLE
fix error handling for decompressGzippedContent #327

### DIFF
--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -91,9 +91,9 @@ export async function decompressGzippedContent(buffer: Buffer, charset?: string)
         zlib.gunzip(buffer, function (error, buffer) {
             if (error) {
                 reject(error);
+            } else {
+                resolve(buffer.toString(charset || 'utf-8'));
             }
-
-            resolve(buffer.toString(charset || 'utf-8'));
         });
     })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-rest-client",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-rest-client",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "description": "Node Rest and Http Clients for use with TypeScript",
   "main": "./RestClient.js",
   "scripts": {


### PR DESCRIPTION
**link to related issue**: #327 

**description**: 
Promise rejection wrapped on the single if without else clause will not stop method execution in case of the error, any other statements which go after the if block will be also executed, which confuses some of IDEs and may cause error in the future
