### PR TITLE
Removed mention of node 4 support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ To build and test you need LTS Node >= 6.12.0 and Npm 5.5.1 (we use lock files).
 For contributions, we recommend using Node 10.15.1 and Npm 6.9.0 in order to minimize friction between package-lock formatting.
 
 ## Build
- 
+
 ```
 $ npm install
 $ npm run build
@@ -15,7 +15,7 @@ $ npm run build
 
 ## Test
 
-You should test with node 4.x, 6.x and 8.x LTS.  We recommend using nvm ([linux](https://github.com/creationix/nvm) / [windows](https://github.com/coreybutler/nvm-windows))
+You should test with node 6.x and 8.x LTS.  We recommend using nvm ([linux](https://github.com/creationix/nvm) / [windows](https://github.com/coreybutler/nvm-windows))
 
 ```
 npm test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ $ npm run build
 
 ## Test
 
-You should test with node 6.x and 8.x LTS.  We recommend using nvm ([linux](https://github.com/creationix/nvm) / [windows](https://github.com/coreybutler/nvm-windows))
+You should test with node 6.x, 8.x and 16.x LTS.  We recommend using nvm ([linux](https://github.com/creationix/nvm) / [windows](https://github.com/coreybutler/nvm-windows))
 
 ```
 npm test

--- a/README.md
+++ b/README.md
@@ -71,11 +71,9 @@ or
 set NODE_DEBUG=http
 ```
 
-
-
 ## Node support
 
-The typed-rest-client is built using the latest LTS version of Node 8. We also support the latest LTS for Node 4 and Node 6.
+The typed-rest-client is built using the latest LTS version of Node 8. We also support the latest LTS for Node 6 and newer.
 
 ## Contributing
 


### PR DESCRIPTION
**Description**: This PR removes mention of node 4 support since it's already not supported for a long time.

Changelog:
- Removed note about node 4 from repo README
- Remove note about node 4 from contributing guide