### PR TITLE
Add ability to pass global agent options for `HttpClient`

### DIFF
--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -121,6 +121,10 @@ export class HttpClient implements ifm.IHttpClient {
     private _ca: string;
     private _cert: string;
     private _key: string;
+    private _httpGlobalAgentOptions: ifm.IHttpGlobalAgentOptions = {
+        keepAlive: false,
+        timeout: 30_000
+    };
 
     constructor(userAgent: string | null | undefined, handlers?: ifm.IRequestHandler[], requestOptions?: ifm.IRequestOptions) {
         this.userAgent = userAgent;
@@ -146,6 +150,10 @@ export class HttpClient implements ifm.IHttpClient {
                 requestOptions.proxy.proxyBypassHosts.forEach(bypass => {
                     this._httpProxyBypassHosts.push(new RegExp(bypass, 'i'));
                 });
+            }
+
+            if (requestOptions.globalAgentOptions) {
+                this._httpGlobalAgentOptions = requestOptions.globalAgentOptions;
             }
 
             this._certConfig = requestOptions.cert;
@@ -529,7 +537,10 @@ export class HttpClient implements ifm.IHttpClient {
 
         // if not using private agent and tunnel agent isn't setup then use global agent
         if (!agent) {
-            const globalAgentOptions: http.AgentOptions = { keepAlive: true, scheduling: "lifo", timeout: 30_000 };
+            const globalAgentOptions: http.AgentOptions = { 
+                keepAlive: this._httpGlobalAgentOptions.keepAlive,
+                timeout: this._httpGlobalAgentOptions.timeout
+            };
             agent = usingSsl ? new https.Agent(globalAgentOptions) : new http.Agent(globalAgentOptions);
         }
 

--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -529,7 +529,8 @@ export class HttpClient implements ifm.IHttpClient {
 
         // if not using private agent and tunnel agent isn't setup then use global agent
         if (!agent) {
-            agent = usingSsl ? https.globalAgent : http.globalAgent;
+            const globalAgentOptions: http.AgentOptions = { keepAlive: true, scheduling: "lifo", timeout: 30_000 };
+            agent = usingSsl ? new https.Agent(globalAgentOptions) : new http.Agent(globalAgentOptions);
         }
 
         if (usingSsl && this._ignoreSslError) {

--- a/lib/Interfaces.ts
+++ b/lib/Interfaces.ts
@@ -47,6 +47,7 @@ export interface IRequestOptions {
     ignoreSslError?: boolean;
     proxy?: IProxyConfiguration;
     cert?: ICertConfiguration;
+    globalAgentOptions?: IHttpGlobalAgentOptions;
     allowRedirects?: boolean;
     allowRedirectDowngrade?: boolean;
     maxRedirects?: number;
@@ -70,6 +71,11 @@ export interface ICertConfiguration {
     certFile?: string;
     keyFile?: string;
     passphrase?: string;
+}
+
+export interface IHttpGlobalAgentOptions {
+    keepAlive?: boolean;
+    timeout?: number;
 }
 
 export interface IRequestQueryParams {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typed-rest-client",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typed-rest-client",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "des.js": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-rest-client",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Node Rest and Http Clients for use with TypeScript",
   "main": "./RestClient.js",
   "scripts": {

--- a/samples/basic/package-lock.json
+++ b/samples/basic/package-lock.json
@@ -18,7 +18,7 @@
     },
     "../../_build": {
       "name": "typed-rest-client",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "des.js": "^1.1.0",

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -14,7 +14,7 @@
     },
     "../_build": {
       "name": "typed-rest-client",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "des.js": "^1.1.0",


### PR DESCRIPTION
**WI**
[AB#2212397](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2212397)

**Description**
Since Node 19 global http agent uses HTTP Keep-Alive and a 5 second timeout by default: https://nodejs.org/api/http.html#httpglobalagent. 

This might cause issues like this one with `UseDotNet` task: https://github.com/microsoft/azure-pipelines-tasks/issues/20396

I added `globalAgentOptions` property to `IRequestOptions` to be able to set `timeout` and `keepAlive` parameters for global agent as needed when using `HttpClient`. 