### PR TITLE
Support for AbortController

### DIFF
--- a/lib/RestClient.ts
+++ b/lib/RestClient.ts
@@ -55,11 +55,12 @@ export class RestClient {
      * @param {IRequestOptions} requestOptions - (optional) requestOptions object
      */
     public async options<T>(requestUrl: string,
-        options?: IRequestOptions): Promise<IRestResponse<T>> {
+        options?: IRequestOptions,
+        signal?: AbortSignal): Promise<IRestResponse<T>> {
 
         let url: string = util.getUrl(requestUrl, this._baseUrl);
         let res: httpm.HttpClientResponse = await this.client.options(url,
-            this._headersFromOptions(options));
+            this._headersFromOptions(options), signal);
         return this.processResponse<T>(res, options);
     }
 
@@ -70,11 +71,12 @@ export class RestClient {
      * @param {IRequestOptions} requestOptions - (optional) requestOptions object
      */
     public async get<T>(resource: string,
-        options?: IRequestOptions): Promise<IRestResponse<T>> {
+        options?: IRequestOptions,
+        signal?: AbortSignal): Promise<IRestResponse<T>> {
 
         let url: string = util.getUrl(resource, this._baseUrl, (options || {}).queryParameters);
         let res: httpm.HttpClientResponse = await this.client.get(url,
-            this._headersFromOptions(options));
+            this._headersFromOptions(options), signal);
         return this.processResponse<T>(res, options);
     }
 
@@ -85,11 +87,12 @@ export class RestClient {
      * @param {IRequestOptions} requestOptions - (optional) requestOptions object
      */
     public async del<T>(resource: string,
-        options?: IRequestOptions): Promise<IRestResponse<T>> {
+        options?: IRequestOptions,
+        signal?: AbortSignal): Promise<IRestResponse<T>> {
 
         let url: string = util.getUrl(resource, this._baseUrl, (options || {}).queryParameters);
         let res: httpm.HttpClientResponse = await this.client.del(url,
-            this._headersFromOptions(options));
+            this._headersFromOptions(options), signal);
         return this.processResponse<T>(res, options);
     }
 
@@ -102,13 +105,14 @@ export class RestClient {
      */
     public async create<T>(resource: string,
         resources: any,
-        options?: IRequestOptions): Promise<IRestResponse<T>> {
+        options?: IRequestOptions,
+        signal?: AbortSignal): Promise<IRestResponse<T>> {
 
         let url: string = util.getUrl(resource, this._baseUrl);
         let headers: ifm.IHeaders = this._headersFromOptions(options, true);
 
         let data: string = JSON.stringify(resources, null, 2);
-        let res: httpm.HttpClientResponse = await this.client.post(url, data, headers);
+        let res: httpm.HttpClientResponse = await this.client.post(url, data, headers, signal);
         return this.processResponse<T>(res, options);
     }
 
@@ -121,13 +125,14 @@ export class RestClient {
      */
     public async update<T>(resource: string,
         resources: any,
-        options?: IRequestOptions): Promise<IRestResponse<T>> {
+        options?: IRequestOptions,
+        signal?: AbortSignal): Promise<IRestResponse<T>> {
 
         let url: string = util.getUrl(resource, this._baseUrl);
         let headers: ifm.IHeaders = this._headersFromOptions(options, true);
 
         let data: string = JSON.stringify(resources, null, 2);
-        let res: httpm.HttpClientResponse = await this.client.patch(url, data, headers);
+        let res: httpm.HttpClientResponse = await this.client.patch(url, data, headers, signal);
         return this.processResponse<T>(res, options);
     }
 
@@ -140,25 +145,27 @@ export class RestClient {
      */
     public async replace<T>(resource: string,
         resources: any,
-        options?: IRequestOptions): Promise<IRestResponse<T>> {
+        options?: IRequestOptions,
+        signal?: AbortSignal): Promise<IRestResponse<T>> {
 
         let url: string = util.getUrl(resource, this._baseUrl);
         let headers: ifm.IHeaders = this._headersFromOptions(options, true);
 
         let data: string = JSON.stringify(resources, null, 2);
-        let res: httpm.HttpClientResponse = await this.client.put(url, data, headers);
+        let res: httpm.HttpClientResponse = await this.client.put(url, data, headers, signal);
         return this.processResponse<T>(res, options);
     }
 
     public async uploadStream<T>(verb: string,
         requestUrl: string,
         stream: NodeJS.ReadableStream,
-        options?: IRequestOptions): Promise<IRestResponse<T>> {
+        options?: IRequestOptions,
+        signal?: AbortSignal): Promise<IRestResponse<T>> {
 
         let url: string = util.getUrl(requestUrl, this._baseUrl);
         let headers: ifm.IHeaders = this._headersFromOptions(options, true);
 
-        let res: httpm.HttpClientResponse = await this.client.sendStream(verb, url, stream, headers);
+        let res: httpm.HttpClientResponse = await this.client.sendStream(verb, url, stream, headers, signal);
         return this.processResponse<T>(res, options);
     }
 


### PR DESCRIPTION
Hi there, thanks for the nice project.

This small PR adds support for Node's AbortController, which is the currently recommended way to abort requests in flight. I couldn't see any way to achieve this in the current version, and as the change is relatively minor I've put this PR quickly together to demonstrate what I mean. AbortControllers are already supported by the underlying `http.request()` and `https.request()` methods; this PR simply passes an optional AbortSignal object through the various function calls to the underlying request.

Usage:

```
// Abort controllers are setup in the usual way.
const controller = new AbortController();

// RestClient also supported.
const client = new HttpClient(
    // Other options.
);

// When you make a request, you can pass the signal from the AbortController.
const request = client.get(
    "https://github.com/",
    {},  // Headers.
    controller.signal
);

// If we change our minds, we can now cancel the request.
controller.abort("No longer needed");

// Causing the promise to reject.
try {
    const val = await request;
} catch (err) {
    console.log(err); // AbortError: No longer needed
}
```

Abort controllers are (sadly) single use only  so specifying at the constructor/object level doesn't really make sense, hence the addition to the method call directly. Some of the method signatures are now getting a bit messy however, it might be more desirable to add `signal` to the `IRequestOptions` or similar instead... 

Apologies if this functionality is unwanted/covered elsewhere.