### PR TITLE
Override elliptic version to 6.6.1

### DIFF
--- a/samples/react/package-lock.json
+++ b/samples/react/package-lock.json
@@ -2378,9 +2378,9 @@
       "license": "ISC"
     },
     "node_modules/elliptic": {
-      "version": "6.5.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/elliptic/-/elliptic-6.5.7.tgz",
-      "integrity": "sha1-jsTaLLKTmSahuac2GddoIH5kfIs=",
+      "version": "6.6.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha1-O4/7AmcL9p44LH9lv1JMl8VAXAY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/samples/react/package.json
+++ b/samples/react/package.json
@@ -28,5 +28,8 @@
     "typescript": "^5.2.2",
     "vite": "^5.2.0",
     "vite-plugin-node-polyfills": "^0.22.0"
+  },
+   "overrides": {
+    "elliptic": "^6.6.1"
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/microsoft/typed-rest-client/security/dependabot/259

The package `elliptic` is present in `package-lock.json` as a transitive dependency, pulled via the following tree:

```json
`-- vite-plugin-node-polyfills@0.22.0
  `-- node-stdlib-browser@1.2.0
    `-- crypto-browserify@3.12.0
      +-- browserify-sign@4.2.3
      | `-- elliptic@6.6.1
      `-- create-ecdh@4.0.4
        `-- elliptic@6.6.1 
```

Both upstream dependencies are compatible with newer versions of `elliptic`:

* **`browserify-sign`** supports `elliptic@^6.5.5`:
  [https://github.com/browserify/browserify-sign/blob/main/package.json](https://github.com/browserify/browserify-sign/blob/main/package.json)
* **`create-ecdh`** supports `elliptic@^6.5.3`:
  [https://github.com/browserify/createECDH/blob/master/package.json](https://github.com/browserify/createECDH/blob/master/package.json)


Added an override in `package.json` to force `elliptic@6.6.1` across all usages:

```json
"overrides": {
  "elliptic": "6.6.1"
}
```

This overrides entries in package-lock.json which uses elliptic version less than 6.6.1