### PR TITLE
Updating the vmimage versions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,8 +14,8 @@ parameters:
 - name: imageList
   type: object
   default: 
-    windows: 'abtt-windows-2022'
-    linux: 'abtt-ubuntu-2204'
+    windows: 'abtt-windows-2025'
+    linux: 'abtt-ubuntu-2404'
 - name: publishToNpm
   displayName: Publish to npm
   type: boolean
@@ -34,7 +34,7 @@ extends:
         enabled: false
       sourceAnalysisPool:
         name: 1ES-ABTT-Shared-Pool
-        image: abtt-windows-2022
+        image: abtt-windows-2025
         os: windows
     customBuildTags:
     - ES365AIMigrationTooling
@@ -46,7 +46,7 @@ extends:
         displayName: Build and Publish artifact
         pool:
           name: 1ES-ABTT-Shared-Pool
-          image: abtt-ubuntu-2204
+          image: abtt-ubuntu-2404
           os: linux
         templateContext:
           outputs:
@@ -102,7 +102,7 @@ extends:
         displayName: Publish npm package
         pool:
           name: 1ES-ABTT-Shared-Pool
-          image: abtt-ubuntu-2204
+          image: abtt-ubuntu-2404
           os: linux
         steps:
         - task: DownloadPipelineArtifact@2


### PR DESCRIPTION
Updated the VMImage versions which are currently using the deprecated versions.

These are the error messages we are getting due to deprecated images:
<img width="2076" height="561" alt="image" src="https://github.com/user-attachments/assets/0dd9e5ea-6da2-488e-9edc-113780b9e825" />
pipeline link: https://dev.azure.com/mseng/PipelineTools/_build/results?buildId=30861029&view=results

After making the changes:
<img width="2005" height="781" alt="image" src="https://github.com/user-attachments/assets/4c85c7a3-3225-49d5-9d5f-f1f2ac01d03c" />
pipeline link: https://dev.azure.com/mseng/PipelineTools/_build/results?buildId=30862339&view=results


Work-item: [AB#2344099](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2344099)