### PR TITLE
Remove Deprecated use of url.parse 

### DIFF
--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -306,7 +306,7 @@ export class HttpClient implements ifm.IHttpClient {
                 }
                 let parsedRedirectUrl: URL;
                 try {
-                    parsedRedirectUrl = new URL(redirectUrl);
+                    parsedRedirectUrl = new URL(redirectUrl, parsedUrl.href);
                 } catch (err) {
                     throw new Error(`Invalid redirect URL: ${redirectUrl}. ${err.message}`);
                 }

--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -253,7 +253,7 @@ export class HttpClient implements ifm.IHttpClient {
         try {
             parsedUrl = new URL(requestUrl);
         } catch (err) {
-            throw new Error(`Invalid URL: ${requestUrl}. ${err.message}`);
+            throw new Error(`Invalid URL: ${err.message}`);
         }
         let info: RequestInfo = this._prepareRequest(verb, parsedUrl, headers);
 
@@ -309,7 +309,7 @@ export class HttpClient implements ifm.IHttpClient {
                 try {
                     parsedRedirectUrl = new URL(redirectUrl, parsedUrl.href);
                 } catch (err) {
-                    throw new Error(`Invalid redirect URL: ${redirectUrl}. ${err.message}`);
+                    throw new Error(`Invalid redirect URL: ${err.message}`);
                 }
                 if (parsedUrl.protocol == 'https:' && parsedUrl.protocol != parsedRedirectUrl.protocol && !this._allowRedirectDowngrade) {
                     throw new Error("Redirect from HTTPS to HTTP protocol. This downgrade is not allowed for security reasons. If you want to allow this behavior, set the allowRedirectDowngrade option to true.");
@@ -600,7 +600,7 @@ export class HttpClient implements ifm.IHttpClient {
                 try {
                     proxyUrl = new URL(proxyConfig.proxyUrl);
                 } catch (err) {
-                    throw new Error(`Invalid proxy URL: ${proxyConfig.proxyUrl}. ${err.message}`);
+                    throw new Error(`Invalid proxy URL: ${err.message}`);
                 }
             }
 

--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -92,8 +92,9 @@ export function isHttps(requestUrl: string) {
     try {
         let parsedUrl: URL = new URL(requestUrl);
         return parsedUrl.protocol === 'https:';
-    } catch (err) {
-        throw new Error(`Invalid URL: ${requestUrl}. ${err.message}`);
+    } catch {
+        // Preserve original boolean semantics: treat invalid/relative URLs as non-HTTPS.
+        return false;
     }
 }
 

--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -597,10 +597,19 @@ export class HttpClient implements ifm.IHttpClient {
         let proxyAuth: string;
         if (proxyConfig) {
             if (proxyConfig.proxyUrl.length > 0) {
+                // Normalize scheme-less proxy URLs (e.g., "proxy.com:8080") for backward
+                // compatibility. The old url.parse() accepted host-only strings, but the
+                // WHATWG URL constructor requires an absolute URL with a scheme.
+                const rawProxyUrl = proxyConfig.proxyUrl;
+                let normalizedProxyUrl = rawProxyUrl;
+                if (!/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(normalizedProxyUrl)) {
+                    // No scheme detected — default to http:// to preserve legacy behavior.
+                    normalizedProxyUrl = `http://${normalizedProxyUrl}`;
+                }
                 try {
-                    proxyUrl = new URL(proxyConfig.proxyUrl);
+                    proxyUrl = new URL(normalizedProxyUrl);
                 } catch (err) {
-                    throw new Error(`Invalid proxy URL: ${err.message}`);
+                    throw new Error(`Invalid proxy URL: ${rawProxyUrl}. ${err.message}`);
                 }
             }
 

--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -441,6 +441,8 @@ export class HttpClient implements ifm.IHttpClient {
         
         info.options = <http.RequestOptions>{};
         info.options.host = info.parsedUrl.hostname;
+        // Note: WHATWG URL strips default ports (e.g., :80 for http, :443 for https),
+        // returning ''. The fallback to defaultPort handles this correctly.
         info.options.port = info.parsedUrl.port ? parseInt(info.parsedUrl.port) : defaultPort;
         info.options.path = (info.parsedUrl.pathname || '') + (info.parsedUrl.search || '');
         info.options.method = method;
@@ -527,7 +529,10 @@ export class HttpClient implements ifm.IHttpClient {
                 proxy: {
                     proxyAuth: proxy.proxyAuth,
                     host: proxy.proxyUrl.hostname,
-                    port: proxy.proxyUrl.port
+                    // WHATWG URL strips default ports (80/443) returning ''.
+                    // The tunnel library needs an explicit port number to connect,
+                    // so fall back to the protocol's default when .port is empty.
+                    port: proxy.proxyUrl.port || (proxy.proxyUrl.protocol === 'https:' ? '443' : '80')
                 },
             };
 

--- a/lib/Interfaces.ts
+++ b/lib/Interfaces.ts
@@ -37,7 +37,7 @@ export interface IHttpClientResponse {
 
 export interface IRequestInfo {
     options: http.RequestOptions;
-    parsedUrl: url.Url;
+    parsedUrl: URL;
     httpModule: any;
 }
 

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -54,7 +54,9 @@ export function getUrl(resource: string, baseUrl?: string, queryParams?: IReques
             } else {
                 // Resource is a relative path - merge with base using path.resolve
                 const protocol = base.protocol;
-                const auth = base.username && base.password ? `${base.username}:${base.password}@` : base.username ? `${base.username}@` : '';
+                const encodedUsername = base.username ? encodeURIComponent(base.username) : '';
+                const encodedPassword = base.password ? encodeURIComponent(base.password) : '';
+                const auth = encodedUsername && encodedPassword ? `${encodedUsername}:${encodedPassword}@` : encodedUsername ? `${encodedUsername}@` : '';
                 const host = base.host;
                 
                 // Use path.resolve for proper path merging (matches original behavior)

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -49,8 +49,23 @@ export function getUrl(resource: string, baseUrl?: string, queryParams?: IReques
             let resultantUrl: URL;
             
             if (isFullUrl) {
-                // Resource is a complete URL, use it entirely
-                resultantUrl = resourceUrl;
+                // Resource is a complete URL – merge missing components from base to preserve previous behavior
+                const mergedUrl = new URL(resourceUrl.href);
+                // Inherit auth if not specified on the resource URL
+                if (!mergedUrl.username && base.username) {
+                    mergedUrl.username = base.username;
+                }
+                if (!mergedUrl.password && base.password) {
+                    mergedUrl.password = base.password;
+                }
+                // Inherit protocol and host if somehow absent on the resource URL
+                if (!mergedUrl.protocol && base.protocol) {
+                    mergedUrl.protocol = base.protocol;
+                }
+                if (!mergedUrl.host && base.host) {
+                    mergedUrl.host = base.host;
+                }
+                resultantUrl = mergedUrl;
             } else {
                 // Resource is a relative path - merge with base using path.resolve
                 const protocol = base.protocol;

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -32,7 +32,7 @@ export function getUrl(resource: string, baseUrl?: string, queryParams?: IReques
             try {
                 base = new URL(baseUrl);
             } catch (err) {
-                throw new Error(`Invalid base URL: ${baseUrl}. ${err.message}`);
+                throw new Error(`Invalid base URL: ${err.message}`);
             }
             
             // Check if resource is a full URL by attempting to parse it
@@ -89,7 +89,7 @@ export function getUrl(resource: string, baseUrl?: string, queryParams?: IReques
             requestUrl = resultantUrl.href;
         } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
-            throw new Error(`Failed to construct URL from resource="${resource}" and baseUrl="${baseUrl}". ${message}`);
+            throw new Error(`Failed to construct URL ${message}`);
         }
     }
 

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -73,7 +73,8 @@ export function getUrl(resource: string, baseUrl?: string, queryParams?: IReques
 
             requestUrl = resultantUrl.href;
         } catch (err) {
-            throw new Error(`Invalid URL: resource="${resource}", baseUrl="${baseUrl}". ${err.message}`);
+            const message = err instanceof Error ? err.message : String(err);
+            throw new Error(`Failed to construct URL from resource="${resource}" and baseUrl="${baseUrl}". ${message}`);
         }
     }
 

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -7,6 +7,25 @@ import * as path from 'path';
 import zlib = require('zlib');
 import { IRequestQueryParams, IHttpClientResponse } from './Interfaces';
 
+//helper function
+ /**
+  * Redacts username and password from a URL string to prevent credential
+  * leakage in error messages, logs, or telemetry.
+  */
+ function sanitizeUrlForError(urlStr: string): string {
+     try {
+         const u = new URL(urlStr);
+         if (u.username || u.password) {
+             u.username = '***';
+             u.password = '***';
+         }
+         return u.href;
+     } catch {
+         // Fallback regex redaction for strings that aren't parseable URLs.
+         return urlStr.replace(/\/\/[^@]+@/, '//***:***@');
+     }
+ }
+
 /**
  * creates an url from a request url and optional base url (http://server:8080)
  * @param {string} resource - a fully qualified url or relative path
@@ -39,13 +58,20 @@ export function getUrl(resource: string, baseUrl?: string, queryParams?: IReques
             let isFullUrl = false;
             let resourceUrl: URL;
             try {
-                resourceUrl = new URL(resource);
+                // Protocol-relative URLs (e.g., "//example.com/path") were treated as
+                // having a host by the old url.parse(). The WHATWG URL constructor
+                // rejects them without a base, so resolve against base.href to
+                // preserve the original merge semantics (inherit protocol from base).
+                if (resource.startsWith('//')) {
+                    resourceUrl = new URL(resource, base.href);
+                } else {
+                    resourceUrl = new URL(resource);
+                }
                 isFullUrl = true;
             } catch {
-                // Resource is not a full URL, treat as relative path
+                // Resource is not a full URL, treat as a relative path to merge with base.
                 isFullUrl = false;
             }
-            
             let resultantUrl: URL;
             
             if (isFullUrl) {
@@ -89,7 +115,10 @@ export function getUrl(resource: string, baseUrl?: string, queryParams?: IReques
             requestUrl = resultantUrl.href;
         } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
-            throw new Error(`Failed to construct URL ${message}`);
+             throw new Error(
+                 `Failed to construct URL from resource="${sanitizeUrlForError(resource)}" ` +
+                 `and baseUrl="${sanitizeUrlForError(baseUrl)}". ${message}`
+             );
         }
     }
 

--- a/test/units/utiltests.ts
+++ b/test/units/utiltests.ts
@@ -28,7 +28,7 @@ describe('Util Tests', function () {
         it('bypasses same domain', () => {
             let regExp = util.buildProxyBypassRegexFromEnv('microsoft.com');
             assert(regExp, 'regExp should not be null');
-            let parsedUrl = url.parse("https://microsoft.com/api/resource");
+            let parsedUrl = new URL("https://microsoft.com/api/resource");
             let bypassed = regExp.test(parsedUrl.href);
             assert.equal(bypassed, true);
         });
@@ -36,7 +36,7 @@ describe('Util Tests', function () {
         it('bypasses subdomain using wildcard', () => {
             let regExp = util.buildProxyBypassRegexFromEnv('*.microsoft.com');
             assert(regExp, 'regExp should not be null');
-            let parsedUrl = url.parse("https://subdomain.microsoft.com/api/resource");
+            let parsedUrl = new URL("https://subdomain.microsoft.com/api/resource");
             let bypassed = regExp.test(parsedUrl.href);
             assert.equal(bypassed, true);
         });       


### PR DESCRIPTION
Deprecation in Node 24: https://nodejs.org/api/deprecations.html#DEP0169

This PR updates use of url.parse to Safer `New URL()`
Impacts how request object is formed by rest-client