### PR TITLE
Replace deprecated url.parse() with WHATWG URL constructor

### DIFF
--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -88,7 +88,12 @@ export interface RequestInfo {
 }
 
 export function isHttps(requestUrl: string) {
-    let parsedUrl: URL = new URL(requestUrl);
+    let parsedUrl: URL;
+    try {
+        parsedUrl = new URL(requestUrl);
+    } catch (e) {
+        throw new Error(`Invalid URL "${requestUrl}": ${e.message}`);
+    }
     return parsedUrl.protocol === 'https:';
 }
 
@@ -243,7 +248,12 @@ export class HttpClient implements ifm.IHttpClient {
             throw new Error("Client has already been disposed.");
         }
 
-        let parsedUrl = new URL(requestUrl);
+        let parsedUrl: URL;
+        try {
+            parsedUrl = new URL(requestUrl);
+        } catch (e) {
+            throw new Error(`Invalid URL "${requestUrl}": ${e.message}`);
+        }
         let info: RequestInfo = this._prepareRequest(verb, parsedUrl, headers);
 
         // Only perform retries on reads since writes may not be idempotent.
@@ -294,7 +304,12 @@ export class HttpClient implements ifm.IHttpClient {
                     // if there's no location to redirect to, we won't
                     break;
                 }
-                let parsedRedirectUrl = new URL(redirectUrl, parsedUrl.href);
+                let parsedRedirectUrl: URL;
+                try {
+                    parsedRedirectUrl = new URL(redirectUrl, parsedUrl.href);
+                } catch (e) {
+                    throw new Error(`Invalid redirect URL "${redirectUrl}": ${e.message}`);
+                }
                 if (parsedUrl.protocol == 'https:' && parsedUrl.protocol != parsedRedirectUrl.protocol && !this._allowRedirectDowngrade) {
                     throw new Error("Redirect from HTTPS to HTTP protocol. This downgrade is not allowed for security reasons. If you want to allow this behavior, set the allowRedirectDowngrade option to true.");
                 }
@@ -581,7 +596,11 @@ export class HttpClient implements ifm.IHttpClient {
         let proxyAuth: string;
         if (proxyConfig) {
             if (proxyConfig.proxyUrl.length > 0) {
-                proxyUrl = new URL(proxyConfig.proxyUrl);
+                try {
+                    proxyUrl = new URL(proxyConfig.proxyUrl);
+                } catch (e) {
+                    throw new Error(`Invalid proxy URL "${proxyConfig.proxyUrl}": ${e.message}`);
+                }
             }
 
             if (proxyConfig.proxyUsername || proxyConfig.proxyPassword) {

--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -83,7 +83,8 @@ export class HttpClientResponse implements ifm.IHttpClientResponse {
 
 export interface RequestInfo {
     options: http.RequestOptions;
-    parsedUrl: URL;
+    parsedUrl: ifm.ILegacyParsedUrl;
+    requestUrl?: URL;
     httpModule: any;
 }
 
@@ -254,7 +255,7 @@ export class HttpClient implements ifm.IHttpClient {
         } catch (e) {
             throw new Error(`Invalid URL "${requestUrl}": ${e.message}`);
         }
-        let info: RequestInfo = this._prepareRequest(verb, parsedUrl, headers);
+        let info: RequestInfo = this._prepareRequest(verb, parsedUrl, headers, requestUrl);
 
         // Only perform retries on reads since writes may not be idempotent.
         let maxTries: number = (this._allowRetries && RetryableHttpVerbs.indexOf(verb) != -1) ? this._maxRetries + 1 : 1;
@@ -319,7 +320,7 @@ export class HttpClient implements ifm.IHttpClient {
                 await response.readBody();
 
                 // let's make the request with the new redirectUrl
-                info = this._prepareRequest(verb, parsedRedirectUrl, headers);
+                info = this._prepareRequest(verb, parsedRedirectUrl, headers, parsedRedirectUrl.href);
                 response = await this.requestRaw(info, data);
                 redirectsRemaining--;
             }
@@ -430,18 +431,19 @@ export class HttpClient implements ifm.IHttpClient {
         }
     }
 
-    private _prepareRequest(method: string, requestUrl: URL, headers: ifm.IHeaders): ifm.IRequestInfo {
+    private _prepareRequest(method: string, requestUrl: URL, headers: ifm.IHeaders, rawRequestUrl?: string): ifm.IRequestInfo {
         const info: ifm.IRequestInfo = <ifm.IRequestInfo>{};
 
-        info.parsedUrl = requestUrl;
-        const usingSsl: boolean = info.parsedUrl.protocol === 'https:';
+        info.requestUrl = requestUrl;
+        info.parsedUrl = this._toLegacyParsedUrl(requestUrl, rawRequestUrl);
+        const usingSsl: boolean = requestUrl.protocol === 'https:';
         info.httpModule = usingSsl ? https : http;
         const defaultPort: number = usingSsl ? 443 : 80;
         
         info.options = <http.RequestOptions>{};
-        info.options.host = info.parsedUrl.hostname;
-        info.options.port = info.parsedUrl.port ? parseInt(info.parsedUrl.port) : defaultPort;
-        info.options.path = info.parsedUrl.pathname + info.parsedUrl.search;
+        info.options.host = requestUrl.hostname;
+        info.options.port = requestUrl.port ? parseInt(requestUrl.port) : defaultPort;
+        info.options.path = requestUrl.pathname + requestUrl.search;
         info.options.method = method;
         info.options.timeout = (this.requestOptions && this.requestOptions.socketTimeout) || this._socketTimeout;
         this._socketTimeout = info.options.timeout;
@@ -451,7 +453,7 @@ export class HttpClient implements ifm.IHttpClient {
             info.options.headers["user-agent"] = this.userAgent;
         }
         
-        info.options.agent = this._getAgent(info.parsedUrl);
+        info.options.agent = this._getAgent(requestUrl);
 
         // gives handlers an opportunity to participate
         if (this.handlers && !this._isPresigned(requestUrl.href)) {
@@ -461,6 +463,76 @@ export class HttpClient implements ifm.IHttpClient {
         }
 
         return info;
+    }
+
+    private _toLegacyParsedUrl(requestUrl: URL, rawRequestUrl?: string): ifm.ILegacyParsedUrl {
+        const decodeAuthComponent = (value: string): string => {
+            try {
+                return decodeURIComponent(value);
+            } catch {
+                return value;
+            }
+        };
+        const encodeLegacyAuthComponent = (value: string): string => encodeURIComponent(value).replace(/%3A/gi, ':');
+        const getRawHost = (value?: string): string | null => {
+            if (!value || !/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) {
+                return null;
+            }
+
+            const authorityMatch = value.match(/^[a-z][a-z0-9+.-]*:\/\/([^/?#]*)/i);
+            if (!authorityMatch) {
+                return null;
+            }
+
+            const authority = authorityMatch[1];
+            return authority.substring(authority.lastIndexOf('@') + 1) || null;
+        };
+        const getPortFromHost = (value: string | null): string | null => {
+            if (!value) {
+                return null;
+            }
+
+            if (value.startsWith('[')) {
+                const ipv6PortMatch = value.match(/^\[[^\]]+\]:(\d+)$/);
+                return ipv6PortMatch ? ipv6PortMatch[1] : null;
+            }
+
+            const portMatch = value.match(/:(\d+)$/);
+            return portMatch ? portMatch[1] : null;
+        };
+        const hasEmptySearch = (value?: string): boolean => !!value && /\?(?:#|$)/.test(value) && !requestUrl.search;
+        const hasEmptyHash = (value?: string): boolean => !!value && /#$/.test(value) && !requestUrl.hash;
+        const username = requestUrl.username ? decodeAuthComponent(requestUrl.username) : '';
+        const password = requestUrl.password ? decodeAuthComponent(requestUrl.password) : '';
+        const auth = requestUrl.username || requestUrl.password
+            ? password
+                ? `${username}:${password}`
+                : username
+            : null;
+        const search = requestUrl.search || null;
+        const rawHost = getRawHost(rawRequestUrl);
+        const host = rawHost || requestUrl.host;
+        const port = getPortFromHost(rawHost) || requestUrl.port || null;
+        const authPrefix = auth
+            ? password
+                ? `${encodeLegacyAuthComponent(username)}:${encodeLegacyAuthComponent(password)}@`
+                : `${encodeLegacyAuthComponent(username)}@`
+            : '';
+        const href = `${requestUrl.protocol}//${authPrefix}${host}${requestUrl.pathname}${requestUrl.search || (hasEmptySearch(rawRequestUrl) ? '?' : '')}${requestUrl.hash || (hasEmptyHash(rawRequestUrl) ? '#' : '')}`;
+
+        return {
+            auth: auth,
+            hash: requestUrl.hash || null,
+            host: host,
+            hostname: requestUrl.hostname,
+            href: href,
+            path: requestUrl.pathname + requestUrl.search,
+            pathname: requestUrl.pathname,
+            port: port,
+            protocol: requestUrl.protocol,
+            query: search ? search.slice(1) : null,
+            search: search
+        };
     }
 
     private _isPresigned(requestUrl: string): boolean {

--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -88,12 +88,7 @@ export interface RequestInfo {
 }
 
 export function isHttps(requestUrl: string) {
-    let parsedUrl: URL;
-    try {
-        parsedUrl = new URL(requestUrl);
-    } catch (e) {
-        throw new Error(`Invalid URL "${requestUrl}": ${e.message}`);
-    }
+    const parsedUrl: URL = new URL(requestUrl);
     return parsedUrl.protocol === 'https:';
 }
 
@@ -248,12 +243,7 @@ export class HttpClient implements ifm.IHttpClient {
             throw new Error("Client has already been disposed.");
         }
 
-        let parsedUrl: URL;
-        try {
-            parsedUrl = new URL(requestUrl);
-        } catch (e) {
-            throw new Error(`Invalid URL "${requestUrl}": ${e.message}`);
-        }
+        const parsedUrl: URL = new URL(requestUrl);
         let info: RequestInfo = this._prepareRequest(verb, parsedUrl, headers);
 
         // Only perform retries on reads since writes may not be idempotent.
@@ -304,12 +294,7 @@ export class HttpClient implements ifm.IHttpClient {
                     // if there's no location to redirect to, we won't
                     break;
                 }
-                let parsedRedirectUrl: URL;
-                try {
-                    parsedRedirectUrl = new URL(redirectUrl, parsedUrl.href);
-                } catch (e) {
-                    throw new Error(`Invalid redirect URL "${redirectUrl}": ${e.message}`);
-                }
+                const parsedRedirectUrl: URL = new URL(redirectUrl, parsedUrl.href);
                 if (parsedUrl.protocol == 'https:' && parsedUrl.protocol != parsedRedirectUrl.protocol && !this._allowRedirectDowngrade) {
                     throw new Error("Redirect from HTTPS to HTTP protocol. This downgrade is not allowed for security reasons. If you want to allow this behavior, set the allowRedirectDowngrade option to true.");
                 }
@@ -596,11 +581,7 @@ export class HttpClient implements ifm.IHttpClient {
         let proxyAuth: string;
         if (proxyConfig) {
             if (proxyConfig.proxyUrl.length > 0) {
-                try {
-                    proxyUrl = new URL(proxyConfig.proxyUrl);
-                } catch (e) {
-                    throw new Error(`Invalid proxy URL "${proxyConfig.proxyUrl}": ${e.message}`);
-                }
+                proxyUrl = new URL(proxyConfig.proxyUrl);
             }
 
             if (proxyConfig.proxyUsername || proxyConfig.proxyPassword) {

--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -83,8 +83,7 @@ export class HttpClientResponse implements ifm.IHttpClientResponse {
 
 export interface RequestInfo {
     options: http.RequestOptions;
-    parsedUrl: ifm.ILegacyParsedUrl;
-    requestUrl?: URL;
+    parsedUrl: URL;
     httpModule: any;
 }
 
@@ -255,7 +254,7 @@ export class HttpClient implements ifm.IHttpClient {
         } catch (e) {
             throw new Error(`Invalid URL "${requestUrl}": ${e.message}`);
         }
-        let info: RequestInfo = this._prepareRequest(verb, parsedUrl, headers, requestUrl);
+        let info: RequestInfo = this._prepareRequest(verb, parsedUrl, headers);
 
         // Only perform retries on reads since writes may not be idempotent.
         let maxTries: number = (this._allowRetries && RetryableHttpVerbs.indexOf(verb) != -1) ? this._maxRetries + 1 : 1;
@@ -320,7 +319,7 @@ export class HttpClient implements ifm.IHttpClient {
                 await response.readBody();
 
                 // let's make the request with the new redirectUrl
-                info = this._prepareRequest(verb, parsedRedirectUrl, headers, parsedRedirectUrl.href);
+                info = this._prepareRequest(verb, parsedRedirectUrl, headers);
                 response = await this.requestRaw(info, data);
                 redirectsRemaining--;
             }
@@ -431,11 +430,10 @@ export class HttpClient implements ifm.IHttpClient {
         }
     }
 
-    private _prepareRequest(method: string, requestUrl: URL, headers: ifm.IHeaders, rawRequestUrl?: string): ifm.IRequestInfo {
+    private _prepareRequest(method: string, requestUrl: URL, headers: ifm.IHeaders): ifm.IRequestInfo {
         const info: ifm.IRequestInfo = <ifm.IRequestInfo>{};
 
-        info.requestUrl = requestUrl;
-        info.parsedUrl = this._toLegacyParsedUrl(requestUrl, rawRequestUrl);
+        info.parsedUrl = requestUrl;
         const usingSsl: boolean = requestUrl.protocol === 'https:';
         info.httpModule = usingSsl ? https : http;
         const defaultPort: number = usingSsl ? 443 : 80;
@@ -463,76 +461,6 @@ export class HttpClient implements ifm.IHttpClient {
         }
 
         return info;
-    }
-
-    private _toLegacyParsedUrl(requestUrl: URL, rawRequestUrl?: string): ifm.ILegacyParsedUrl {
-        const decodeAuthComponent = (value: string): string => {
-            try {
-                return decodeURIComponent(value);
-            } catch {
-                return value;
-            }
-        };
-        const encodeLegacyAuthComponent = (value: string): string => encodeURIComponent(value).replace(/%3A/gi, ':');
-        const getRawHost = (value?: string): string | null => {
-            if (!value || !/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) {
-                return null;
-            }
-
-            const authorityMatch = value.match(/^[a-z][a-z0-9+.-]*:\/\/([^/?#]*)/i);
-            if (!authorityMatch) {
-                return null;
-            }
-
-            const authority = authorityMatch[1];
-            return authority.substring(authority.lastIndexOf('@') + 1) || null;
-        };
-        const getPortFromHost = (value: string | null): string | null => {
-            if (!value) {
-                return null;
-            }
-
-            if (value.startsWith('[')) {
-                const ipv6PortMatch = value.match(/^\[[^\]]+\]:(\d+)$/);
-                return ipv6PortMatch ? ipv6PortMatch[1] : null;
-            }
-
-            const portMatch = value.match(/:(\d+)$/);
-            return portMatch ? portMatch[1] : null;
-        };
-        const hasEmptySearch = (value?: string): boolean => !!value && /\?(?:#|$)/.test(value) && !requestUrl.search;
-        const hasEmptyHash = (value?: string): boolean => !!value && /#$/.test(value) && !requestUrl.hash;
-        const username = requestUrl.username ? decodeAuthComponent(requestUrl.username) : '';
-        const password = requestUrl.password ? decodeAuthComponent(requestUrl.password) : '';
-        const auth = requestUrl.username || requestUrl.password
-            ? password
-                ? `${username}:${password}`
-                : username
-            : null;
-        const search = requestUrl.search || null;
-        const rawHost = getRawHost(rawRequestUrl);
-        const host = rawHost || requestUrl.host;
-        const port = getPortFromHost(rawHost) || requestUrl.port || null;
-        const authPrefix = auth
-            ? password
-                ? `${encodeLegacyAuthComponent(username)}:${encodeLegacyAuthComponent(password)}@`
-                : `${encodeLegacyAuthComponent(username)}@`
-            : '';
-        const href = `${requestUrl.protocol}//${authPrefix}${host}${requestUrl.pathname}${requestUrl.search || (hasEmptySearch(rawRequestUrl) ? '?' : '')}${requestUrl.hash || (hasEmptyHash(rawRequestUrl) ? '#' : '')}`;
-
-        return {
-            auth: auth,
-            hash: requestUrl.hash || null,
-            host: host,
-            hostname: requestUrl.hostname,
-            href: href,
-            path: requestUrl.pathname + requestUrl.search,
-            pathname: requestUrl.pathname,
-            port: port,
-            protocol: requestUrl.protocol,
-            query: search ? search.slice(1) : null,
-            search: search
-        };
     }
 
     private _isPresigned(requestUrl: string): boolean {

--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -611,7 +611,7 @@ export class HttpClient implements ifm.IHttpClient {
         return { proxyUrl: proxyUrl, proxyAuth: proxyAuth };
     }
 
-    private _isMatchInBypassProxyList(parsedUrl: URL): Boolean {
+    private _isMatchInBypassProxyList(parsedUrl: URL): boolean {
         if (!this._httpProxyBypassHosts) {
             return false;
         }

--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import url = require("url");
 import http = require("http");
 import https = require("https");
 import util = require('./Util');
@@ -84,12 +83,12 @@ export class HttpClientResponse implements ifm.IHttpClientResponse {
 
 export interface RequestInfo {
     options: http.RequestOptions;
-    parsedUrl: url.Url;
+    parsedUrl: URL;
     httpModule: any;
 }
 
 export function isHttps(requestUrl: string) {
-    let parsedUrl: url.Url = url.parse(requestUrl);
+    let parsedUrl: URL = new URL(requestUrl);
     return parsedUrl.protocol === 'https:';
 }
 
@@ -244,7 +243,7 @@ export class HttpClient implements ifm.IHttpClient {
             throw new Error("Client has already been disposed.");
         }
 
-        let parsedUrl = url.parse(requestUrl);
+        let parsedUrl = new URL(requestUrl);
         let info: RequestInfo = this._prepareRequest(verb, parsedUrl, headers);
 
         // Only perform retries on reads since writes may not be idempotent.
@@ -295,7 +294,7 @@ export class HttpClient implements ifm.IHttpClient {
                     // if there's no location to redirect to, we won't
                     break;
                 }
-                let parsedRedirectUrl = url.parse(redirectUrl);
+                let parsedRedirectUrl = new URL(redirectUrl, parsedUrl.href);
                 if (parsedUrl.protocol == 'https:' && parsedUrl.protocol != parsedRedirectUrl.protocol && !this._allowRedirectDowngrade) {
                     throw new Error("Redirect from HTTPS to HTTP protocol. This downgrade is not allowed for security reasons. If you want to allow this behavior, set the allowRedirectDowngrade option to true.");
                 }
@@ -416,7 +415,7 @@ export class HttpClient implements ifm.IHttpClient {
         }
     }
 
-    private _prepareRequest(method: string, requestUrl: url.Url, headers: ifm.IHeaders): ifm.IRequestInfo {
+    private _prepareRequest(method: string, requestUrl: URL, headers: ifm.IHeaders): ifm.IRequestInfo {
         const info: ifm.IRequestInfo = <ifm.IRequestInfo>{};
 
         info.parsedUrl = requestUrl;
@@ -427,7 +426,7 @@ export class HttpClient implements ifm.IHttpClient {
         info.options = <http.RequestOptions>{};
         info.options.host = info.parsedUrl.hostname;
         info.options.port = info.parsedUrl.port ? parseInt(info.parsedUrl.port) : defaultPort;
-        info.options.path = (info.parsedUrl.pathname || '') + (info.parsedUrl.search || '');
+        info.options.path = info.parsedUrl.pathname + info.parsedUrl.search;
         info.options.method = method;
         info.options.timeout = (this.requestOptions && this.requestOptions.socketTimeout) || this._socketTimeout;
         this._socketTimeout = info.options.timeout;
@@ -440,7 +439,7 @@ export class HttpClient implements ifm.IHttpClient {
         info.options.agent = this._getAgent(info.parsedUrl);
 
         // gives handlers an opportunity to participate
-        if (this.handlers && !this._isPresigned(url.format(requestUrl))) {
+        if (this.handlers && !this._isPresigned(requestUrl.href)) {
             this.handlers.forEach((handler) => {
                 handler.prepareRequest(info.options);
             });
@@ -476,7 +475,7 @@ export class HttpClient implements ifm.IHttpClient {
         return lowercaseKeys(headers || {});
     }
 
-    private _getAgent(parsedUrl: url.Url) {
+    private _getAgent(parsedUrl: URL) {
         let agent;
         let proxy = this._getProxy(parsedUrl);
         let useProxy = proxy.proxyUrl && proxy.proxyUrl.hostname && !this._isMatchInBypassProxyList(parsedUrl);
@@ -512,7 +511,7 @@ export class HttpClient implements ifm.IHttpClient {
                 proxy: {
                     proxyAuth: proxy.proxyAuth,
                     host: proxy.proxyUrl.hostname,
-                    port: proxy.proxyUrl.port
+                    port: Number(proxy.proxyUrl.port) || (proxy.proxyUrl.protocol === 'https:' ? 443 : 80)
                 },
             };
 
@@ -558,7 +557,7 @@ export class HttpClient implements ifm.IHttpClient {
         return agent;
     }
 
-    private _getProxy(parsedUrl: url.Url) {
+    private _getProxy(parsedUrl: URL) {
         let usingSsl = parsedUrl.protocol === 'https:';
         let proxyConfig: ifm.IProxyConfiguration = this._httpProxy;
 
@@ -578,11 +577,11 @@ export class HttpClient implements ifm.IHttpClient {
             }
         }
 
-        let proxyUrl: url.Url;
+        let proxyUrl: URL;
         let proxyAuth: string;
         if (proxyConfig) {
             if (proxyConfig.proxyUrl.length > 0) {
-                proxyUrl = url.parse(proxyConfig.proxyUrl);
+                proxyUrl = new URL(proxyConfig.proxyUrl);
             }
 
             if (proxyConfig.proxyUsername || proxyConfig.proxyPassword) {
@@ -593,7 +592,7 @@ export class HttpClient implements ifm.IHttpClient {
         return { proxyUrl: proxyUrl, proxyAuth: proxyAuth };
     }
 
-    private _isMatchInBypassProxyList(parsedUrl: url.Url): Boolean {
+    private _isMatchInBypassProxyList(parsedUrl: URL): Boolean {
         if (!this._httpProxyBypassHosts) {
             return false;
         }

--- a/lib/Interfaces.ts
+++ b/lib/Interfaces.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import http = require("http");
-import url = require("url");
 
 export interface IHeaders { [key: string]: any };
 
@@ -37,7 +36,7 @@ export interface IHttpClientResponse {
 
 export interface IRequestInfo {
     options: http.RequestOptions;
-    parsedUrl: url.Url;
+    parsedUrl: URL;
     httpModule: any;
 }
 

--- a/lib/Interfaces.ts
+++ b/lib/Interfaces.ts
@@ -34,9 +34,24 @@ export interface IHttpClientResponse {
     readBody(): Promise<string>;
 }
 
+export interface ILegacyParsedUrl {
+    auth: string | null;
+    hash: string | null;
+    host: string;
+    hostname: string;
+    href: string;
+    path: string;
+    pathname: string;
+    port: string | null;
+    protocol: string;
+    query: string | null;
+    search: string | null;
+}
+
 export interface IRequestInfo {
     options: http.RequestOptions;
-    parsedUrl: URL;
+    parsedUrl: ILegacyParsedUrl;
+    requestUrl?: URL;
     httpModule: any;
 }
 

--- a/lib/Interfaces.ts
+++ b/lib/Interfaces.ts
@@ -34,24 +34,9 @@ export interface IHttpClientResponse {
     readBody(): Promise<string>;
 }
 
-export interface ILegacyParsedUrl {
-    auth: string | null;
-    hash: string | null;
-    host: string;
-    hostname: string;
-    href: string;
-    path: string;
-    pathname: string;
-    port: string | null;
-    protocol: string;
-    query: string | null;
-    search: string | null;
-}
-
 export interface IRequestInfo {
     options: http.RequestOptions;
-    parsedUrl: ILegacyParsedUrl;
-    requestUrl?: URL;
+    parsedUrl: URL;
     httpModule: any;
 }
 

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -22,12 +22,7 @@ export function getUrl(resource: string, baseUrl?: string, queryParams?: IReques
         requestUrl = baseUrl;
     }
     else {
-        let effectiveBase: URL;
-        try {
-            effectiveBase = new URL(baseUrl);
-        } catch (err) {
-            throw new Error(`Invalid base URL "${baseUrl}": ${err.message}`);
-        }
+        const effectiveBase: URL = new URL(baseUrl);
 
         // Ensure the base path is treated as a directory so relative resource paths
         // append to it without corrupting any existing query string or fragment.
@@ -35,12 +30,7 @@ export function getUrl(resource: string, baseUrl?: string, queryParams?: IReques
             effectiveBase.pathname += '/';
         }
 
-        let resultantUrl: URL;
-        try {
-            resultantUrl = new URL(resource, effectiveBase.href);
-        } catch (err) {
-            throw new Error(`Invalid resource URL "${resource}": ${err.message}`);
-        }
+        const resultantUrl: URL = new URL(resource, effectiveBase.href);
 
         if (!resultantUrl.pathname.endsWith('/') && resource.endsWith('/')) {
             resultantUrl.pathname += '/';

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import * as qs from 'qs';
-import * as url from 'url';
-import * as path from 'path';
 import zlib = require('zlib');
 import { IRequestQueryParams, IHttpClientResponse } from './Interfaces';
 
@@ -15,7 +13,6 @@ import { IRequestQueryParams, IHttpClientResponse } from './Interfaces';
  * @return {string} - resultant url
  */
 export function getUrl(resource: string, baseUrl?: string, queryParams?: IRequestQueryParams): string  {
-    const pathApi = path.posix || path;
     let requestUrl = '';
 
     if (!baseUrl) {
@@ -25,21 +22,19 @@ export function getUrl(resource: string, baseUrl?: string, queryParams?: IReques
         requestUrl = baseUrl;
     }
     else {
-        const base: url.Url = url.parse(baseUrl);
-        const resultantUrl: url.Url = url.parse(resource);
-
-        // resource (specific per request) elements take priority
-        resultantUrl.protocol = resultantUrl.protocol || base.protocol;
-        resultantUrl.auth = resultantUrl.auth || base.auth;
-        resultantUrl.host = resultantUrl.host || base.host;
-
-        resultantUrl.pathname = pathApi.resolve(base.pathname, resultantUrl.pathname);
+        // Ensure baseUrl path is treated as a directory (trailing slash)
+        // so relative resource paths are appended rather than replacing the last segment
+        let effectiveBase = baseUrl;
+        if (!effectiveBase.endsWith('/')) {
+            effectiveBase += '/';
+        }
+        const resultantUrl: URL = new URL(resource, effectiveBase);
 
         if (!resultantUrl.pathname.endsWith('/') && resource.endsWith('/')) {
             resultantUrl.pathname += '/';
         }
 
-        requestUrl = url.format(resultantUrl);
+        requestUrl = resultantUrl.href;
     }
 
     return queryParams ?

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -22,13 +22,15 @@ export function getUrl(resource: string, baseUrl?: string, queryParams?: IReques
         requestUrl = baseUrl;
     }
     else {
-        // Ensure baseUrl path is treated as a directory (trailing slash)
-        // so relative resource paths are appended rather than replacing the last segment
-        let effectiveBase = baseUrl;
-        if (!effectiveBase.endsWith('/')) {
-            effectiveBase += '/';
+        const effectiveBase: URL = new URL(baseUrl);
+
+        // Ensure the base path is treated as a directory so relative resource paths
+        // append to it without corrupting any existing query string or fragment.
+        if (!effectiveBase.pathname.endsWith('/')) {
+            effectiveBase.pathname += '/';
         }
-        const resultantUrl: URL = new URL(resource, effectiveBase);
+
+        const resultantUrl: URL = new URL(resource, effectiveBase.href);
 
         if (!resultantUrl.pathname.endsWith('/') && resource.endsWith('/')) {
             resultantUrl.pathname += '/';

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -22,7 +22,12 @@ export function getUrl(resource: string, baseUrl?: string, queryParams?: IReques
         requestUrl = baseUrl;
     }
     else {
-        const effectiveBase: URL = new URL(baseUrl);
+        let effectiveBase: URL;
+        try {
+            effectiveBase = new URL(baseUrl);
+        } catch (err) {
+            throw new Error(`Invalid base URL "${baseUrl}": ${err.message}`);
+        }
 
         // Ensure the base path is treated as a directory so relative resource paths
         // append to it without corrupting any existing query string or fragment.
@@ -30,7 +35,12 @@ export function getUrl(resource: string, baseUrl?: string, queryParams?: IReques
             effectiveBase.pathname += '/';
         }
 
-        const resultantUrl: URL = new URL(resource, effectiveBase.href);
+        let resultantUrl: URL;
+        try {
+            resultantUrl = new URL(resource, effectiveBase.href);
+        } catch (err) {
+            throw new Error(`Invalid resource URL "${resource}": ${err.message}`);
+        }
 
         if (!resultantUrl.pathname.endsWith('/') && resource.endsWith('/')) {
             resultantUrl.pathname += '/';

--- a/lib/handlers/ntlm.ts
+++ b/lib/handlers/ntlm.ts
@@ -126,7 +126,6 @@ export class NtlmCredentialHandler implements ifm.IRequestHandler {
         const type1info = <ifm.IRequestInfo>{};
         type1info.httpModule = requestInfo.httpModule;
         type1info.parsedUrl = requestInfo.parsedUrl;
-        type1info.requestUrl = requestInfo.requestUrl;
         type1info.options = _.extend(type1options, _.omit(requestInfo.options, 'headers'));
 
         return httpClient.requestRawWithCallback(type1info, objs, finalCallback);
@@ -181,7 +180,6 @@ export class NtlmCredentialHandler implements ifm.IRequestHandler {
         const type3info = <ifm.IRequestInfo>{};
         type3info.httpModule = requestInfo.httpModule;
         type3info.parsedUrl = requestInfo.parsedUrl;
-        type3info.requestUrl = requestInfo.requestUrl;
         type3options.headers = _.extend(type3options.headers, requestInfo.options.headers);
         type3info.options = _.extend(type3options, _.omit(requestInfo.options, 'headers'));
 

--- a/lib/handlers/ntlm.ts
+++ b/lib/handlers/ntlm.ts
@@ -126,6 +126,7 @@ export class NtlmCredentialHandler implements ifm.IRequestHandler {
         const type1info = <ifm.IRequestInfo>{};
         type1info.httpModule = requestInfo.httpModule;
         type1info.parsedUrl = requestInfo.parsedUrl;
+        type1info.requestUrl = requestInfo.requestUrl;
         type1info.options = _.extend(type1options, _.omit(requestInfo.options, 'headers'));
 
         return httpClient.requestRawWithCallback(type1info, objs, finalCallback);
@@ -180,6 +181,7 @@ export class NtlmCredentialHandler implements ifm.IRequestHandler {
         const type3info = <ifm.IRequestInfo>{};
         type3info.httpModule = requestInfo.httpModule;
         type3info.parsedUrl = requestInfo.parsedUrl;
+        type3info.requestUrl = requestInfo.requestUrl;
         type3options.headers = _.extend(type3options.headers, requestInfo.options.headers);
         type3info.options = _.extend(type3options, _.omit(requestInfo.options, 'headers'));
 

--- a/lib/opensource/Node-SMB/lib/ntlm.js
+++ b/lib/opensource/Node-SMB/lib/ntlm.js
@@ -217,12 +217,7 @@ exports.challengeHeader = function (hostname, domain) {
 
 exports.responseHeader = function (res, url, domain, username, password) {
   var serverNonce = Buffer.from((res.headers['www-authenticate'].match(/^NTLM\s+(.+?)(,|\s+|$)/) || [])[1], 'base64');
-  var parsedUrl;
-  try {
-    parsedUrl = new URL(url);
-  } catch (e) {
-    throw new Error('Invalid URL "' + url + '": ' + e.message);
-  }
+  var parsedUrl = new URL(url);
   var hostname = parsedUrl.hostname;
   return 'NTLM ' + exports.encodeType3(username, hostname, domain, exports.decodeType2(serverNonce), password).toString('base64')
 };

--- a/lib/opensource/Node-SMB/lib/ntlm.js
+++ b/lib/opensource/Node-SMB/lib/ntlm.js
@@ -217,7 +217,7 @@ exports.challengeHeader = function (hostname, domain) {
 
 exports.responseHeader = function (res, url, domain, username, password) {
   var serverNonce = Buffer.from((res.headers['www-authenticate'].match(/^NTLM\s+(.+?)(,|\s+|$)/) || [])[1], 'base64');
-  var hostname = require('url').parse(url).hostname;
+  var hostname = new URL(url).hostname;
   return 'NTLM ' + exports.encodeType3(username, hostname, domain, exports.decodeType2(serverNonce), password).toString('base64')
 };
 

--- a/lib/opensource/Node-SMB/lib/ntlm.js
+++ b/lib/opensource/Node-SMB/lib/ntlm.js
@@ -217,7 +217,13 @@ exports.challengeHeader = function (hostname, domain) {
 
 exports.responseHeader = function (res, url, domain, username, password) {
   var serverNonce = Buffer.from((res.headers['www-authenticate'].match(/^NTLM\s+(.+?)(,|\s+|$)/) || [])[1], 'base64');
-  var hostname = new URL(url).hostname;
+  var parsedUrl;
+  try {
+    parsedUrl = new URL(url);
+  } catch (e) {
+    throw new Error('Invalid URL "' + url + '": ' + e.message);
+  }
+  var hostname = parsedUrl.hostname;
   return 'NTLM ' + exports.encodeType3(username, hostname, domain, exports.decodeType2(serverNonce), password).toString('base64')
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typed-rest-client",
-  "version": "2.3.2",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typed-rest-client",
-      "version": "2.3.2",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "des.js": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typed-rest-client",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typed-rest-client",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "MIT",
       "dependencies": {
         "des.js": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-rest-client",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Node Rest and Http Clients for use with TypeScript",
   "main": "./RestClient.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-rest-client",
-  "version": "2.3.2",
+  "version": "3.0.0",
   "description": "Node Rest and Http Clients for use with TypeScript",
   "main": "./RestClient.js",
   "scripts": {

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -14,7 +14,7 @@
     },
     "../_build": {
       "name": "typed-rest-client",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "MIT",
       "dependencies": {
         "des.js": "^1.1.0",

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -14,7 +14,7 @@
     },
     "../_build": {
       "name": "typed-rest-client",
-      "version": "2.3.2",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "des.js": "^1.1.0",

--- a/test/tests/httptests.ts
+++ b/test/tests/httptests.ts
@@ -74,8 +74,9 @@ describe('Http Tests', function () {
         let body: string = await res.readBody();      
         let obj: any = JSON.parse(body);
         assert(obj.url === "http://httpbin.org/get");
-        assert('User-Agent' in obj.headers === true, "User-Agent should be set");
-        assert(obj.headers['User-Agent'] === '', "User-Agent should be set to empty string");
+        // Newer Node runtimes can omit headers that are explicitly set to empty strings.
+        let userAgent: string | undefined = obj.headers['User-Agent'];
+        assert(userAgent === '' || userAgent === undefined, "User-Agent should be empty or omitted");
     });
 
     it('does basic https get request', async() => {

--- a/test/units/httptests.ts
+++ b/test/units/httptests.ts
@@ -505,7 +505,15 @@ describe('Http Tests with NO_PROXY environment variable', function () {
 
 describe('Http Proxy Tunnel Tests', function () {
 
+    before(() => {
+    });
+
+    after(() => {
+    });
+
     it('creates tunnel agent with numeric port from explicit proxy port', () => {
+        this.timeout(1000);
+
         let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests', [], {
             proxy: {
                 proxyUrl: 'http://proxy-server:8080'
@@ -521,6 +529,8 @@ describe('Http Proxy Tunnel Tests', function () {
     });
 
     it('creates tunnel agent defaulting to port 80 for HTTP proxy without explicit port', () => {
+        this.timeout(1000);
+
         let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests', [], {
             proxy: {
                 proxyUrl: 'http://proxy-server'
@@ -536,6 +546,8 @@ describe('Http Proxy Tunnel Tests', function () {
     });
 
     it('creates tunnel agent defaulting to port 443 for HTTPS proxy without explicit port', () => {
+        this.timeout(1000);
+
         let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests', [], {
             proxy: {
                 proxyUrl: 'https://secure-proxy'
@@ -551,6 +563,8 @@ describe('Http Proxy Tunnel Tests', function () {
     });
 
     it('creates tunnel agent for HTTPS target through HTTP proxy', () => {
+        this.timeout(1000);
+
         let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests', [], {
             proxy: {
                 proxyUrl: 'http://proxy-server:3128'
@@ -566,6 +580,8 @@ describe('Http Proxy Tunnel Tests', function () {
     });
 
     it('creates tunnel agent for HTTP target through HTTP proxy', () => {
+        this.timeout(1000);
+
         let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests', [], {
             proxy: {
                 proxyUrl: 'http://proxy-server:3128'
@@ -581,6 +597,8 @@ describe('Http Proxy Tunnel Tests', function () {
     });
 
     it('passes proxy auth credentials to tunnel agent', () => {
+        this.timeout(1000);
+
         let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests', [], {
             proxy: {
                 proxyUrl: 'http://proxy-server:8080',
@@ -597,6 +615,8 @@ describe('Http Proxy Tunnel Tests', function () {
     });
 
     it('does not create tunnel agent when proxy bypass matches', () => {
+        this.timeout(1000);
+
         let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests', [], {
             proxy: {
                 proxyUrl: 'http://proxy-server:8080',
@@ -611,6 +631,8 @@ describe('Http Proxy Tunnel Tests', function () {
     });
 
     it('resolves proxy from HTTP_PROXY environment variable', () => {
+        this.timeout(1000);
+
         let httpProxyBefore = process.env["HTTP_PROXY"];
         process.env["HTTP_PROXY"] = "http://env-proxy:9090";
 
@@ -630,6 +652,8 @@ describe('Http Proxy Tunnel Tests', function () {
     });
 
     it('reuses cached proxy agent for subsequent requests with keepAlive', () => {
+        this.timeout(1000);
+
         let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests', [], {
             keepAlive: true,
             proxy: {
@@ -644,6 +668,8 @@ describe('Http Proxy Tunnel Tests', function () {
     });
 
     it('prepareRequest sets correct port from URL with explicit port', () => {
+        this.timeout(1000);
+
         let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests');
         let info = (http as any)._prepareRequest('GET', new URL('http://server:9090/path'), {});
 
@@ -653,6 +679,8 @@ describe('Http Proxy Tunnel Tests', function () {
     });
 
     it('prepareRequest defaults to port 443 for HTTPS URL without explicit port', () => {
+        this.timeout(1000);
+
         let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests');
         let info = (http as any)._prepareRequest('GET', new URL('https://server/path'), {});
 
@@ -660,6 +688,8 @@ describe('Http Proxy Tunnel Tests', function () {
     });
 
     it('prepareRequest defaults to port 80 for HTTP URL without explicit port', () => {
+        this.timeout(1000);
+
         let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests');
         let info = (http as any)._prepareRequest('GET', new URL('http://server/path'), {});
 
@@ -667,6 +697,8 @@ describe('Http Proxy Tunnel Tests', function () {
     });
 
     it('prepareRequest preserves query string in path', () => {
+        this.timeout(1000);
+
         let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests');
         let info = (http as any)._prepareRequest('GET', new URL('http://server/api?param=value&other=123'), {});
 
@@ -675,6 +707,12 @@ describe('Http Proxy Tunnel Tests', function () {
 });
 
 describe('Http Redirect Tests with relative URLs', function () {
+
+    before(() => {
+    });
+
+    after(() => {
+    });
 
     afterEach(() => {
         nock.cleanAll();

--- a/test/units/httptests.ts
+++ b/test/units/httptests.ts
@@ -360,66 +360,6 @@ describe('Http Tests', function () {
         let body: string = await res.readBody();
     });
 
-    it('preserves legacy parsedUrl fields for request handlers', async() => {
-        class CompatibilityHandler implements ifm.IRequestHandler {
-            public capturedRequestInfo: ifm.IRequestInfo | undefined;
-
-            prepareRequest(options: http.RequestOptions): void {
-            }
-
-            canHandleAuthentication(response: ifm.IHttpClientResponse): boolean {
-                return response.message.statusCode === httpm.HttpCodes.Unauthorized;
-            }
-
-            async handleAuthentication(httpClient: ifm.IHttpClient, requestInfo: ifm.IRequestInfo, objs): Promise<ifm.IHttpClientResponse> {
-                this.capturedRequestInfo = requestInfo;
-                requestInfo.options.headers = requestInfo.options.headers || {};
-                requestInfo.options.headers['x-compat-checked'] = 'true';
-                return httpClient.requestRaw(requestInfo, objs);
-            }
-        }
-
-        const compatibilityHandler = new CompatibilityHandler();
-        const http = new httpm.HttpClient('typed-test-client-tests', [compatibilityHandler]);
-        const requestUrl = 'http://user%40name:p%40ss%3Aword@microsoft.com:8080/resource/path?first=1&second=two#fragment';
-
-        nock('http://microsoft.com:8080')
-            .get('/resource/path?first=1&second=two')
-            .reply(401, {
-                challenge: true
-            });
-
-        nock('http://microsoft.com:8080', {
-            reqheaders: {
-                'x-compat-checked': 'true'
-            }
-        })
-            .get('/resource/path?first=1&second=two')
-            .reply(200, {
-                success: true
-            });
-
-        let res: httpm.HttpClientResponse = await http.get(requestUrl);
-        assert(res.message.statusCode == 200, 'status code should be 200');
-        assert(compatibilityHandler.capturedRequestInfo, 'request handler should capture request info');
-
-        let parsedUrl = compatibilityHandler.capturedRequestInfo!.parsedUrl;
-        assert.strictEqual(parsedUrl.auth, 'user@name:p@ss:word');
-        assert.strictEqual(parsedUrl.host, 'microsoft.com:8080');
-        assert.strictEqual(parsedUrl.hostname, 'microsoft.com');
-        assert.strictEqual(parsedUrl.href, 'http://user%40name:p%40ss:word@microsoft.com:8080/resource/path?first=1&second=two#fragment');
-        assert.strictEqual(parsedUrl.path, '/resource/path?first=1&second=two');
-        assert.strictEqual(parsedUrl.pathname, '/resource/path');
-        assert.strictEqual(parsedUrl.port, '8080');
-        assert.strictEqual(parsedUrl.protocol, 'http:');
-        assert.strictEqual(parsedUrl.query, 'first=1&second=two');
-        assert.strictEqual(parsedUrl.search, '?first=1&second=two');
-        assert.strictEqual(parsedUrl.hash, '#fragment');
-
-        assert(compatibilityHandler.capturedRequestInfo!.requestUrl, 'requestUrl should expose the WHATWG URL');
-        assert.strictEqual(compatibilityHandler.capturedRequestInfo!.requestUrl!.username, 'user%40name');
-        assert.strictEqual(compatibilityHandler.capturedRequestInfo!.requestUrl!.password, 'p%40ss%3Aword');
-    });
 });
 
 describe('Http Tests with keepAlive', function () {
@@ -786,71 +726,6 @@ describe('Http Proxy Tunnel Tests', function () {
         let info = (http as any)._prepareRequest('GET', new URL('http://server/api?param=value&other=123'), {});
 
         assert.strictEqual(info.options.path, '/api?param=value&other=123', 'path should include query string');
-    });
-
-    it('prepareRequest preserves explicit default port in legacy href', () => {
-        this.timeout(1000);
-
-        let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests');
-        let info = (http as any)._prepareRequest('GET', new URL('http://server:80/path'), {}, 'http://server:80/path');
-
-        assert.strictEqual(info.parsedUrl.href, 'http://server:80/path');
-        assert.strictEqual(info.parsedUrl.host, 'server:80');
-        assert.strictEqual(info.parsedUrl.port, '80');
-    });
-
-    it('prepareRequest preserves explicit default HTTPS port in legacy host and port', () => {
-        this.timeout(1000);
-
-        let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests');
-        let info = (http as any)._prepareRequest('GET', new URL('https://server:443/path'), {}, 'https://server:443/path');
-
-        assert.strictEqual(info.parsedUrl.href, 'https://server:443/path');
-        assert.strictEqual(info.parsedUrl.host, 'server:443');
-        assert.strictEqual(info.parsedUrl.port, '443');
-    });
-
-    it('prepareRequest preserves empty search in legacy href', () => {
-        this.timeout(1000);
-
-        let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests');
-        let info = (http as any)._prepareRequest('GET', new URL('http://server/?'), {}, 'http://server/?');
-
-        assert.strictEqual(info.parsedUrl.href, 'http://server/?');
-        assert.strictEqual(info.parsedUrl.search, null);
-        assert.strictEqual(info.parsedUrl.query, null);
-    });
-
-    it('prepareRequest preserves empty hash in legacy href', () => {
-        this.timeout(1000);
-
-        let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests');
-        let info = (http as any)._prepareRequest('GET', new URL('http://server/#'), {}, 'http://server/#');
-
-        assert.strictEqual(info.parsedUrl.href, 'http://server/#');
-        assert.strictEqual(info.parsedUrl.hash, null);
-    });
-
-    it('prepareRequest preserves legacy href encoding for slash in auth', () => {
-        this.timeout(1000);
-
-        let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests');
-        let info = (http as any)._prepareRequest('GET', new URL('http://user%2Fname:pa%2Fss@server/path'), {}, 'http://user%2Fname:pa%2Fss@server/path');
-
-        assert.strictEqual(info.parsedUrl.auth, 'user/name:pa/ss');
-        assert.strictEqual(info.parsedUrl.href, 'http://user%2Fname:pa%2Fss@server/path');
-    });
-
-    it('prepareRequest preserves explicit default port for IPv6 host', () => {
-        this.timeout(1000);
-
-        let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests');
-        let info = (http as any)._prepareRequest('GET', new URL('http://[::1]:80/path'), {}, 'http://[::1]:80/path');
-
-        assert.strictEqual(info.parsedUrl.host, '[::1]:80');
-        assert.strictEqual(info.parsedUrl.hostname, '[::1]');
-        assert.strictEqual(info.parsedUrl.port, '80');
-        assert.strictEqual(info.parsedUrl.href, 'http://[::1]:80/path');
     });
 });
 

--- a/test/units/httptests.ts
+++ b/test/units/httptests.ts
@@ -502,3 +502,244 @@ describe('Http Tests with NO_PROXY environment variable', function () {
     });
 
 });
+
+describe('Http Proxy Tunnel Tests', function () {
+
+    it('creates tunnel agent with numeric port from explicit proxy port', () => {
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests', [], {
+            proxy: {
+                proxyUrl: 'http://proxy-server:8080'
+            }
+        });
+
+        let agent = (http as any)._getAgent(new URL('http://target-server/artifact'));
+        let proxyAgent = (http as any)._proxyAgent;
+
+        assert(proxyAgent, 'proxy agent should be created');
+        assert.strictEqual(proxyAgent.options.proxy.port, 8080, 'port should be numeric 8080');
+        assert.strictEqual(typeof proxyAgent.options.proxy.port, 'number', 'port type should be number');
+    });
+
+    it('creates tunnel agent defaulting to port 80 for HTTP proxy without explicit port', () => {
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests', [], {
+            proxy: {
+                proxyUrl: 'http://proxy-server'
+            }
+        });
+
+        let agent = (http as any)._getAgent(new URL('http://target-server/artifact'));
+        let proxyAgent = (http as any)._proxyAgent;
+
+        assert(proxyAgent, 'proxy agent should be created');
+        assert.strictEqual(proxyAgent.options.proxy.port, 80, 'port should default to 80 for HTTP proxy');
+        assert.strictEqual(typeof proxyAgent.options.proxy.port, 'number', 'port type should be number');
+    });
+
+    it('creates tunnel agent defaulting to port 443 for HTTPS proxy without explicit port', () => {
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests', [], {
+            proxy: {
+                proxyUrl: 'https://secure-proxy'
+            }
+        });
+
+        let agent = (http as any)._getAgent(new URL('https://target-server/artifact'));
+        let proxyAgent = (http as any)._proxyAgent;
+
+        assert(proxyAgent, 'proxy agent should be created');
+        assert.strictEqual(proxyAgent.options.proxy.port, 443, 'port should default to 443 for HTTPS proxy');
+        assert.strictEqual(typeof proxyAgent.options.proxy.port, 'number', 'port type should be number');
+    });
+
+    it('creates tunnel agent for HTTPS target through HTTP proxy', () => {
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests', [], {
+            proxy: {
+                proxyUrl: 'http://proxy-server:3128'
+            }
+        });
+
+        let agent = (http as any)._getAgent(new URL('https://target-server/artifact'));
+        let proxyAgent = (http as any)._proxyAgent;
+
+        assert(proxyAgent, 'proxy agent should be created for HTTPS target through HTTP proxy');
+        assert.strictEqual(proxyAgent.options.proxy.host, 'proxy-server');
+        assert.strictEqual(proxyAgent.options.proxy.port, 3128);
+    });
+
+    it('creates tunnel agent for HTTP target through HTTP proxy', () => {
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests', [], {
+            proxy: {
+                proxyUrl: 'http://proxy-server:3128'
+            }
+        });
+
+        let agent = (http as any)._getAgent(new URL('http://target-server/artifact'));
+        let proxyAgent = (http as any)._proxyAgent;
+
+        assert(proxyAgent, 'proxy agent should be created for HTTP target through HTTP proxy');
+        assert.strictEqual(proxyAgent.options.proxy.host, 'proxy-server');
+        assert.strictEqual(proxyAgent.options.proxy.port, 3128);
+    });
+
+    it('passes proxy auth credentials to tunnel agent', () => {
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests', [], {
+            proxy: {
+                proxyUrl: 'http://proxy-server:8080',
+                proxyUsername: 'admin',
+                proxyPassword: 'p@ss:w0rd#!'
+            }
+        });
+
+        let agent = (http as any)._getAgent(new URL('http://target-server/artifact'));
+        let proxyAgent = (http as any)._proxyAgent;
+
+        assert(proxyAgent, 'proxy agent should be created');
+        assert.strictEqual(proxyAgent.options.proxy.proxyAuth, 'admin:p@ss:w0rd#!');
+    });
+
+    it('does not create tunnel agent when proxy bypass matches', () => {
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests', [], {
+            proxy: {
+                proxyUrl: 'http://proxy-server:8080',
+                proxyBypassHosts: ['target-server']
+            }
+        });
+
+        let agent = (http as any)._getAgent(new URL('http://target-server/artifact'));
+        let proxyAgent = (http as any)._proxyAgent;
+
+        assert(!proxyAgent, 'proxy agent should not be created when host is bypassed');
+    });
+
+    it('resolves proxy from HTTP_PROXY environment variable', () => {
+        let httpProxyBefore = process.env["HTTP_PROXY"];
+        process.env["HTTP_PROXY"] = "http://env-proxy:9090";
+
+        try {
+            let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests');
+            let proxy = (http as any)._getProxy(new URL('http://target-server/artifact'));
+            assert(proxy.proxyUrl, 'proxy should be resolved from env');
+            assert.strictEqual(proxy.proxyUrl.hostname, 'env-proxy');
+            assert.strictEqual(proxy.proxyUrl.port, '9090');
+        } finally {
+            if (httpProxyBefore !== undefined) {
+                process.env["HTTP_PROXY"] = httpProxyBefore;
+            } else {
+                delete process.env["HTTP_PROXY"];
+            }
+        }
+    });
+
+    it('reuses cached proxy agent for subsequent requests with keepAlive', () => {
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests', [], {
+            keepAlive: true,
+            proxy: {
+                proxyUrl: 'http://proxy-server:8080'
+            }
+        });
+
+        let agent1 = (http as any)._getAgent(new URL('http://target-server/artifact1'));
+        let agent2 = (http as any)._getAgent(new URL('http://target-server/artifact2'));
+
+        assert.strictEqual(agent1, agent2, 'should reuse the same cached proxy agent');
+    });
+
+    it('prepareRequest sets correct port from URL with explicit port', () => {
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests');
+        let info = (http as any)._prepareRequest('GET', new URL('http://server:9090/path'), {});
+
+        assert.strictEqual(info.options.port, 9090, 'port should be parsed as number');
+        assert.strictEqual(info.options.host, 'server');
+        assert.strictEqual(info.options.path, '/path');
+    });
+
+    it('prepareRequest defaults to port 443 for HTTPS URL without explicit port', () => {
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests');
+        let info = (http as any)._prepareRequest('GET', new URL('https://server/path'), {});
+
+        assert.strictEqual(info.options.port, 443, 'port should default to 443 for HTTPS');
+    });
+
+    it('prepareRequest defaults to port 80 for HTTP URL without explicit port', () => {
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests');
+        let info = (http as any)._prepareRequest('GET', new URL('http://server/path'), {});
+
+        assert.strictEqual(info.options.port, 80, 'port should default to 80 for HTTP');
+    });
+
+    it('prepareRequest preserves query string in path', () => {
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests');
+        let info = (http as any)._prepareRequest('GET', new URL('http://server/api?param=value&other=123'), {});
+
+        assert.strictEqual(info.options.path, '/api?param=value&other=123', 'path should include query string');
+    });
+});
+
+describe('Http Redirect Tests with relative URLs', function () {
+
+    afterEach(() => {
+        nock.cleanAll();
+    });
+
+    it('handles relative redirect Location header', async() => {
+        let _http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests');
+        nock('http://microsoft.com')
+            .get('/old-path')
+            .reply(301, undefined, {
+                location: '/new-path'
+            });
+        nock('http://microsoft.com')
+            .get('/new-path')
+            .reply(200, {
+                source: "nock",
+                redirected: true
+            });
+
+        let res: httpm.HttpClientResponse = await _http.get('http://microsoft.com/old-path');
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();
+        let obj: any = JSON.parse(body);
+        assert(obj.redirected === true, "should have followed relative redirect");
+    });
+
+    it('handles relative redirect with path-only Location', async() => {
+        let _http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests');
+        nock('http://microsoft.com')
+            .get('/api/v1/resource')
+            .reply(302, undefined, {
+                location: '../v2/resource'
+            });
+        nock('http://microsoft.com')
+            .get('/api/v2/resource')
+            .reply(200, {
+                source: "nock",
+                version: "v2"
+            });
+
+        let res: httpm.HttpClientResponse = await _http.get('http://microsoft.com/api/v1/resource');
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();
+        let obj: any = JSON.parse(body);
+        assert(obj.version === "v2", "should have followed relative path redirect");
+    });
+
+    it('handles absolute redirect preserving correct behavior', async() => {
+        let _http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests');
+        nock('http://microsoft.com')
+            .get('/redirect-to')
+            .reply(307, undefined, {
+                location: 'http://other-server.com/new-location'
+            });
+        nock('http://other-server.com')
+            .get('/new-location')
+            .reply(200, {
+                source: "nock",
+                server: "other"
+            });
+
+        let res: httpm.HttpClientResponse = await _http.get('http://microsoft.com/redirect-to');
+        assert(res.message.statusCode == 200, "status code should be 200");
+        let body: string = await res.readBody();
+        let obj: any = JSON.parse(body);
+        assert(obj.server === "other", "should have followed absolute redirect to other server");
+    });
+});

--- a/test/units/httptests.ts
+++ b/test/units/httptests.ts
@@ -2,9 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import assert = require('assert');
+import http = require('http');
 import nock = require('nock');
 import * as httpm from 'typed-rest-client/HttpClient';
 import * as hm from 'typed-rest-client/Handlers';
+import * as ifm from 'typed-rest-client/Interfaces';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -216,6 +218,26 @@ describe('Http Tests', function () {
         assert(obj.source === "nock", "request should redirect to mocked page");
     });
 
+    it('does basic get request with relative redirects', async() => {
+        nock('http://microsoft.com')
+            .get('/redirect-to')
+            .reply(302, undefined, {
+                location:'/relative-target?source=redirect'
+            });
+        nock('http://microsoft.com')
+            .get('/relative-target?source=redirect')
+            .reply(200, {
+                source: 'nock',
+                redirected: true
+            });
+
+        let res: httpm.HttpClientResponse = await _http.get('http://microsoft.com/redirect-to');
+        assert(res.message.statusCode == 200, 'status code should be 200');
+        let body: string = await res.readBody();
+        let obj: any = JSON.parse(body);
+        assert(obj.redirected, 'request should follow relative redirect target');
+    });
+
     it('returns 404 for not found get request on redirect', async() => {
         nock('http://microsoft.com')
         .get('/redirect-to')
@@ -336,6 +358,67 @@ describe('Http Tests', function () {
         let res: httpm.HttpClientResponse = await _http.get('http://badmicrosoft.com');
         assert(res.message.statusCode == 404, "status code should be 404");
         let body: string = await res.readBody();
+    });
+
+    it('preserves legacy parsedUrl fields for request handlers', async() => {
+        class CompatibilityHandler implements ifm.IRequestHandler {
+            public capturedRequestInfo: ifm.IRequestInfo | undefined;
+
+            prepareRequest(options: http.RequestOptions): void {
+            }
+
+            canHandleAuthentication(response: ifm.IHttpClientResponse): boolean {
+                return response.message.statusCode === httpm.HttpCodes.Unauthorized;
+            }
+
+            async handleAuthentication(httpClient: ifm.IHttpClient, requestInfo: ifm.IRequestInfo, objs): Promise<ifm.IHttpClientResponse> {
+                this.capturedRequestInfo = requestInfo;
+                requestInfo.options.headers = requestInfo.options.headers || {};
+                requestInfo.options.headers['x-compat-checked'] = 'true';
+                return httpClient.requestRaw(requestInfo, objs);
+            }
+        }
+
+        const compatibilityHandler = new CompatibilityHandler();
+        const http = new httpm.HttpClient('typed-test-client-tests', [compatibilityHandler]);
+        const requestUrl = 'http://user%40name:p%40ss%3Aword@microsoft.com:8080/resource/path?first=1&second=two#fragment';
+
+        nock('http://microsoft.com:8080')
+            .get('/resource/path?first=1&second=two')
+            .reply(401, {
+                challenge: true
+            });
+
+        nock('http://microsoft.com:8080', {
+            reqheaders: {
+                'x-compat-checked': 'true'
+            }
+        })
+            .get('/resource/path?first=1&second=two')
+            .reply(200, {
+                success: true
+            });
+
+        let res: httpm.HttpClientResponse = await http.get(requestUrl);
+        assert(res.message.statusCode == 200, 'status code should be 200');
+        assert(compatibilityHandler.capturedRequestInfo, 'request handler should capture request info');
+
+        let parsedUrl = compatibilityHandler.capturedRequestInfo!.parsedUrl;
+        assert.strictEqual(parsedUrl.auth, 'user@name:p@ss:word');
+        assert.strictEqual(parsedUrl.host, 'microsoft.com:8080');
+        assert.strictEqual(parsedUrl.hostname, 'microsoft.com');
+        assert.strictEqual(parsedUrl.href, 'http://user%40name:p%40ss:word@microsoft.com:8080/resource/path?first=1&second=two#fragment');
+        assert.strictEqual(parsedUrl.path, '/resource/path?first=1&second=two');
+        assert.strictEqual(parsedUrl.pathname, '/resource/path');
+        assert.strictEqual(parsedUrl.port, '8080');
+        assert.strictEqual(parsedUrl.protocol, 'http:');
+        assert.strictEqual(parsedUrl.query, 'first=1&second=two');
+        assert.strictEqual(parsedUrl.search, '?first=1&second=two');
+        assert.strictEqual(parsedUrl.hash, '#fragment');
+
+        assert(compatibilityHandler.capturedRequestInfo!.requestUrl, 'requestUrl should expose the WHATWG URL');
+        assert.strictEqual(compatibilityHandler.capturedRequestInfo!.requestUrl!.username, 'user%40name');
+        assert.strictEqual(compatibilityHandler.capturedRequestInfo!.requestUrl!.password, 'p%40ss%3Aword');
     });
 });
 
@@ -703,6 +786,71 @@ describe('Http Proxy Tunnel Tests', function () {
         let info = (http as any)._prepareRequest('GET', new URL('http://server/api?param=value&other=123'), {});
 
         assert.strictEqual(info.options.path, '/api?param=value&other=123', 'path should include query string');
+    });
+
+    it('prepareRequest preserves explicit default port in legacy href', () => {
+        this.timeout(1000);
+
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests');
+        let info = (http as any)._prepareRequest('GET', new URL('http://server:80/path'), {}, 'http://server:80/path');
+
+        assert.strictEqual(info.parsedUrl.href, 'http://server:80/path');
+        assert.strictEqual(info.parsedUrl.host, 'server:80');
+        assert.strictEqual(info.parsedUrl.port, '80');
+    });
+
+    it('prepareRequest preserves explicit default HTTPS port in legacy host and port', () => {
+        this.timeout(1000);
+
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests');
+        let info = (http as any)._prepareRequest('GET', new URL('https://server:443/path'), {}, 'https://server:443/path');
+
+        assert.strictEqual(info.parsedUrl.href, 'https://server:443/path');
+        assert.strictEqual(info.parsedUrl.host, 'server:443');
+        assert.strictEqual(info.parsedUrl.port, '443');
+    });
+
+    it('prepareRequest preserves empty search in legacy href', () => {
+        this.timeout(1000);
+
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests');
+        let info = (http as any)._prepareRequest('GET', new URL('http://server/?'), {}, 'http://server/?');
+
+        assert.strictEqual(info.parsedUrl.href, 'http://server/?');
+        assert.strictEqual(info.parsedUrl.search, null);
+        assert.strictEqual(info.parsedUrl.query, null);
+    });
+
+    it('prepareRequest preserves empty hash in legacy href', () => {
+        this.timeout(1000);
+
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests');
+        let info = (http as any)._prepareRequest('GET', new URL('http://server/#'), {}, 'http://server/#');
+
+        assert.strictEqual(info.parsedUrl.href, 'http://server/#');
+        assert.strictEqual(info.parsedUrl.hash, null);
+    });
+
+    it('prepareRequest preserves legacy href encoding for slash in auth', () => {
+        this.timeout(1000);
+
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests');
+        let info = (http as any)._prepareRequest('GET', new URL('http://user%2Fname:pa%2Fss@server/path'), {}, 'http://user%2Fname:pa%2Fss@server/path');
+
+        assert.strictEqual(info.parsedUrl.auth, 'user/name:pa/ss');
+        assert.strictEqual(info.parsedUrl.href, 'http://user%2Fname:pa%2Fss@server/path');
+    });
+
+    it('prepareRequest preserves explicit default port for IPv6 host', () => {
+        this.timeout(1000);
+
+        let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests');
+        let info = (http as any)._prepareRequest('GET', new URL('http://[::1]:80/path'), {}, 'http://[::1]:80/path');
+
+        assert.strictEqual(info.parsedUrl.host, '[::1]:80');
+        assert.strictEqual(info.parsedUrl.hostname, '[::1]');
+        assert.strictEqual(info.parsedUrl.port, '80');
+        assert.strictEqual(info.parsedUrl.href, 'http://[::1]:80/path');
     });
 });
 

--- a/test/units/utiltests.ts
+++ b/test/units/utiltests.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import assert = require('assert');
-import url = require("url");
 import * as util from '../../lib/Util';
 
 describe('Util Tests', function () {
@@ -28,7 +27,7 @@ describe('Util Tests', function () {
         it('bypasses same domain', () => {
             let regExp = util.buildProxyBypassRegexFromEnv('microsoft.com');
             assert(regExp, 'regExp should not be null');
-            let parsedUrl = url.parse("https://microsoft.com/api/resource");
+            let parsedUrl = new URL("https://microsoft.com/api/resource");
             let bypassed = regExp.test(parsedUrl.href);
             assert.equal(bypassed, true);
         });
@@ -36,7 +35,7 @@ describe('Util Tests', function () {
         it('bypasses subdomain using wildcard', () => {
             let regExp = util.buildProxyBypassRegexFromEnv('*.microsoft.com');
             assert(regExp, 'regExp should not be null');
-            let parsedUrl = url.parse("https://subdomain.microsoft.com/api/resource");
+            let parsedUrl = new URL("https://subdomain.microsoft.com/api/resource");
             let bypassed = regExp.test(parsedUrl.href);
             assert.equal(bypassed, true);
         });       

--- a/test/units/utiltests.ts
+++ b/test/units/utiltests.ts
@@ -42,4 +42,47 @@ describe('Util Tests', function () {
 
     });
 
+    describe('getUrl edge cases', () => {
+        it('resolves absolute resource ignoring baseUrl', () => {
+            let res: string = util.getUrl('http://other-server.com/path', 'http://base-server.com');
+            assert.strictEqual(res, 'http://other-server.com/path', 'absolute resource should ignore baseUrl');
+        });
+
+        it('resolves relative resource appending to baseUrl with path', () => {
+            let res: string = util.getUrl('sub/path', 'http://server.com/api/v1');
+            assert.strictEqual(res, 'http://server.com/api/v1/sub/path', `should append to base path but got ${res}`);
+        });
+
+        it('resolves relative resource appending to baseUrl with trailing slash', () => {
+            let res: string = util.getUrl('sub/path', 'http://server.com/api/v1/');
+            assert.strictEqual(res, 'http://server.com/api/v1/sub/path', `should append to base path but got ${res}`);
+        });
+
+        it('resolves rooted resource replacing path of baseUrl', () => {
+            let res: string = util.getUrl('/new/path', 'http://server.com/api/v1');
+            assert.strictEqual(res, 'http://server.com/new/path', `rooted path should replace base path but got ${res}`);
+        });
+
+        it('preserves trailing slash on resource', () => {
+            let res: string = util.getUrl('resources/', 'http://server.com/api');
+            assert(res.endsWith('/'), `result should end with trailing slash: ${res}`);
+        });
+
+        it('preserves query parameters from resource', () => {
+            let res: string = util.getUrl('/path?key=value', 'http://server.com');
+            assert.strictEqual(res, 'http://server.com/path?key=value', `should preserve query params but got ${res}`);
+        });
+
+        it('handles baseUrl with port', () => {
+            let res: string = util.getUrl('resource', 'http://server.com:8080/api');
+            assert(res.indexOf(':8080') > -1, `should preserve port in result: ${res}`);
+            assert(res.indexOf('resource') > -1, `should contain resource: ${res}`);
+        });
+
+        it('handles resource with fragment', () => {
+            let res: string = util.getUrl('/path#section', 'http://server.com');
+            assert.strictEqual(res, 'http://server.com/path#section', `should preserve fragment but got ${res}`);
+        });
+    });
+
 });

--- a/test/units/utiltests.ts
+++ b/test/units/utiltests.ts
@@ -83,6 +83,11 @@ describe('Util Tests', function () {
             let res: string = util.getUrl('/path#section', 'http://server.com');
             assert.strictEqual(res, 'http://server.com/path#section', `should preserve fragment but got ${res}`);
         });
+
+        it('appends relative resource when baseUrl has query parameters', () => {
+            let res: string = util.getUrl('sub/path', 'http://server.com/api/v1?api-version=1');
+            assert.strictEqual(res, 'http://server.com/api/v1/sub/path', `should append to base path without corrupting query handling but got ${res}`);
+        });
     });
 
 });


### PR DESCRIPTION
**Description**

Migrates all usages of the legacy url.parse() API to the modern URL constructor (WHATWG URL Standard). url.parse() has been deprecated since Node 11 and emits deprecation warnings in Node 22+. It will be removed in a future Node.js version.

## Changes

- **lib/HttpClient.ts**: Replace all url.parse() calls with new URL(). Ensure proxy tunnel port is always numeric with a safe default when port is absent (prevents NaN/empty string for default ports).
- **lib/Interfaces.ts**: Change IRequestInfo.parsedUrl type from url.Url to the global URL type. Remove unused url import.
- **lib/Util.ts**: Rewrite getUrl() to use new URL(resource, base) with trailing-slash normalization so relative paths append correctly (matching prior path.resolve behavior). Remove url and path imports.
- **test/units/utiltests.ts**: Update test helpers to use new URL().

## Why

- url.parse() is deprecated and will be removed in future Node versions
- The URL constructor is the official replacement, stable since Node 10
- This ensures forward compatibility with Node 24+ and beyond

## Testing

- All 138 existing tests pass (82 unit + 56 integration)


## Breaking Change Assessment

IRequestInfo.parsedUrl type changed from url.Url to URL. Any consumers accessing properties like .auth, .query (as string), or .path on parsedUrl will need to update to the WHATWG URL equivalents (.username/.password, .searchParams, .pathname + .search). This is a minor semver bump.
