### PR TITLE
Migrate npm publishing to ESRP Release

### DIFF
--- a/.azure-pipelines/azure-pipelines-release.yml
+++ b/.azure-pipelines/azure-pipelines-release.yml
@@ -59,8 +59,8 @@ extends:
           displayName: Authenticate npm feed
           inputs:
             workingFile: .npmrc
-        - script: npm install
-          displayName: npm install
+        - script: npm ci
+          displayName: npm ci
         - script: npm run build
           displayName: npm run build
         - script: npm test
@@ -145,8 +145,8 @@ extends:
             displayName: Authenticate npm feed
             inputs:
               workingFile: .npmrc
-          - script: npm install
-            displayName: npm install
+          - script: npm ci
+            displayName: npm ci
           - bash: |
               case "$BUILD_SOURCEBRANCH" in
                 refs/heads/*)

--- a/.azure-pipelines/azure-pipelines-release.yml
+++ b/.azure-pipelines/azure-pipelines-release.yml
@@ -12,12 +12,6 @@ parameters:
 variables:
 - group: esrp-npm-release
 - group: github-release
-- name: EsrpMainPublisher
-  value: 'ESRPRELPACMAN'
-- name: EsrpServiceEndpointUrl
-  value: 'https://api.esrp.microsoft.com'
-- name: EsrpDomainTenantId
-  value: '975f013f-7f24-47e8-a7d3-abc4752bf346'
 - name: nodeVersion
   value: '20.x'
 

--- a/.azure-pipelines/azure-pipelines-release.yml
+++ b/.azure-pipelines/azure-pipelines-release.yml
@@ -3,6 +3,12 @@ name: $(Date:yyyyMMdd)$(Rev:.r)
 trigger: none
 pr: none
 
+parameters:
+- name: dryRun
+  displayName: Validate build and package without releasing
+  type: boolean
+  default: false
+
 variables:
 - group: esrp-npm-release
 - group: github-release
@@ -83,77 +89,78 @@ extends:
             done
           displayName: Verify package excludes SBOM manifest
 
-    - stage: PublishToNpmViaESRP
-      displayName: Publish to npm via ESRP
-      dependsOn: BuildAndPack
-      jobs:
-      - job: esrp
-        displayName: Publish npm package
-        pool:
-          name: 1ES-ABTT-Shared-Pool
-          image: abtt-windows-2025
-          os: windows
-        templateContext:
-          type: releaseJob
-          isProduction: true
-          inputs:
-          - input: pipelineArtifact
-            artifactName: npm-packages
-            targetPath: $(Pipeline.Workspace)/npm-packages
-        steps:
-        - task: EsrpRelease@12
-          displayName: Publish package to npm via ESRP
-          inputs:
-            connectedservicename: '$(EsrpServiceConnection)'
-            usemanagedidentity: true
-            keyvaultname: '$(EsrpKeyVault)'
-            signcertname: '$(EsrpSignCert)'
-            clientid: '$(EsrpClientId)'
-            intent: 'PackageDistribution'
-            contenttype: 'npm'
-            contentsource: 'Folder'
-            folderlocation: '$(Pipeline.Workspace)/npm-packages/packages'
-            waitforreleasecompletion: true
-            owners: '$(EsrpOwners)'
-            approvers: '$(EsrpApprovers)'
-            serviceendpointurl: '$(EsrpServiceEndpointUrl)'
-            mainpublisher: '$(EsrpMainPublisher)'
-            domaintenantid: '$(EsrpDomainTenantId)'
+    - ${{ if eq(parameters.dryRun, false) }}:
+      - stage: PublishToNpmViaESRP
+        displayName: Publish to npm via ESRP
+        dependsOn: BuildAndPack
+        jobs:
+        - job: esrp
+          displayName: Publish npm package
+          pool:
+            name: 1ES-ABTT-Shared-Pool
+            image: abtt-windows-2025
+            os: windows
+          templateContext:
+            type: releaseJob
+            isProduction: true
+            inputs:
+            - input: pipelineArtifact
+              artifactName: npm-packages
+              targetPath: $(Pipeline.Workspace)/npm-packages
+          steps:
+          - task: EsrpRelease@12
+            displayName: Publish package to npm via ESRP
+            inputs:
+              connectedservicename: '$(EsrpServiceConnection)'
+              usemanagedidentity: true
+              keyvaultname: '$(EsrpKeyVault)'
+              signcertname: '$(EsrpSignCert)'
+              clientid: '$(EsrpClientId)'
+              intent: 'PackageDistribution'
+              contenttype: 'npm'
+              contentsource: 'Folder'
+              folderlocation: '$(Pipeline.Workspace)/npm-packages/packages'
+              waitforreleasecompletion: true
+              owners: '$(EsrpOwners)'
+              approvers: '$(EsrpApprovers)'
+              serviceendpointurl: '$(EsrpServiceEndpointUrl)'
+              mainpublisher: '$(EsrpMainPublisher)'
+              domaintenantid: '$(EsrpDomainTenantId)'
 
-      - job: github_release
-        displayName: Create GitHub release
-        dependsOn: esrp
-        pool:
-          name: 1ES-ABTT-Shared-Pool
-          image: abtt-ubuntu-2404
-          os: linux
-        steps:
-        - checkout: self
-          fetchDepth: 0
-        - task: NodeTool@0
-          displayName: Install Node.js $(nodeVersion)
-          inputs:
-            versionSpec: $(nodeVersion)
-        - task: NpmAuthenticate@0
-          displayName: Authenticate npm feed
-          inputs:
-            workingFile: .npmrc
-        - script: npm install
-          displayName: npm install
-        - bash: |
-            case "$BUILD_SOURCEBRANCH" in
-              refs/heads/*)
-                release_branch="${BUILD_SOURCEBRANCH#refs/heads/}"
-                ;;
-              *)
-                echo "ERROR: Releases must run from a branch, not $BUILD_SOURCEBRANCH"
-                exit 1
-                ;;
-            esac
-            echo "##vso[task.setvariable variable=releaseBranch]$release_branch"
-          displayName: Resolve release branch
-        - script: node ./ci/create-release-notes.js
+        - job: github_release
           displayName: Create GitHub release
-          env:
-            GH_TOKEN: $(gh-automation.token)
-            branch: $(releaseBranch)
+          dependsOn: esrp
+          pool:
+            name: 1ES-ABTT-Shared-Pool
+            image: abtt-ubuntu-2404
+            os: linux
+          steps:
+          - checkout: self
+            fetchDepth: 0
+          - task: NodeTool@0
+            displayName: Install Node.js $(nodeVersion)
+            inputs:
+              versionSpec: $(nodeVersion)
+          - task: NpmAuthenticate@0
+            displayName: Authenticate npm feed
+            inputs:
+              workingFile: .npmrc
+          - script: npm install
+            displayName: npm install
+          - bash: |
+              case "$BUILD_SOURCEBRANCH" in
+                refs/heads/*)
+                  release_branch="${BUILD_SOURCEBRANCH#refs/heads/}"
+                  ;;
+                *)
+                  echo "ERROR: Releases must run from a branch, not $BUILD_SOURCEBRANCH"
+                  exit 1
+                  ;;
+              esac
+              echo "##vso[task.setvariable variable=releaseBranch]$release_branch"
+            displayName: Resolve release branch
+          - script: node ./ci/create-release-notes.js
+            displayName: Create GitHub release
+            env:
+              GH_TOKEN: $(gh-automation.token)
+              branch: $(releaseBranch)

--- a/.azure-pipelines/azure-pipelines-release.yml
+++ b/.azure-pipelines/azure-pipelines-release.yml
@@ -1,0 +1,159 @@
+name: $(Date:yyyyMMdd)$(Rev:.r)
+
+trigger: none
+pr: none
+
+variables:
+- group: esrp-npm-release
+- group: github-release
+- name: EsrpMainPublisher
+  value: 'ESRPRELPACMAN'
+- name: EsrpServiceEndpointUrl
+  value: 'https://api.esrp.microsoft.com'
+- name: EsrpDomainTenantId
+  value: '975f013f-7f24-47e8-a7d3-abc4752bf346'
+- name: nodeVersion
+  value: '20.x'
+
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    sdl:
+      sourceAnalysisPool:
+        name: 1ES-ABTT-Shared-Pool
+        image: abtt-windows-2025
+        os: windows
+    stages:
+    - stage: BuildAndPack
+      displayName: Build, test, and pack
+      jobs:
+      - job: pack
+        pool:
+          name: 1ES-ABTT-Shared-Pool
+          image: abtt-ubuntu-2404
+          os: linux
+        templateContext:
+          outputs:
+          - output: pipelineArtifact
+            targetPath: $(Build.ArtifactStagingDirectory)/npm-packages
+            artifactName: npm-packages
+        steps:
+        - task: NodeTool@0
+          displayName: Install Node.js $(nodeVersion)
+          inputs:
+            versionSpec: $(nodeVersion)
+        - task: NpmAuthenticate@0
+          displayName: Authenticate npm feed
+          inputs:
+            workingFile: .npmrc
+        - script: npm install
+          displayName: npm install
+        - script: npm run build
+          displayName: npm run build
+        - script: npm test
+          displayName: npm test
+        - script: |
+            set -e
+            mkdir -p "$(Build.ArtifactStagingDirectory)/npm-packages/packages"
+            npm pack --pack-destination "$(Build.ArtifactStagingDirectory)/npm-packages/packages"
+          displayName: Pack typed-rest-client
+          workingDirectory: _build
+        - script: |
+            count=$(ls -1 "$(Build.ArtifactStagingDirectory)/npm-packages/packages"/*.tgz 2>/dev/null | wc -l)
+            echo "Found $count .tgz file(s)."
+            if [ "$count" -eq 0 ]; then
+              echo "ERROR: npm pack produced no .tgz"
+              exit 1
+            fi
+          displayName: Verify package exists
+        - script: |
+            set -e
+            for tgz in "$(Build.ArtifactStagingDirectory)/npm-packages/packages"/*.tgz; do
+              if tar -tzf "$tgz" | grep -E '(^|/)_manifest/'; then
+                echo "ERROR: $tgz contains an SBOM _manifest/ folder"
+                exit 1
+              fi
+            done
+          displayName: Verify package excludes SBOM manifest
+
+    - stage: PublishToNpmViaESRP
+      displayName: Publish to npm via ESRP
+      dependsOn: BuildAndPack
+      jobs:
+      - job: esrp
+        displayName: Publish npm package
+        pool:
+          name: 1ES-ABTT-Shared-Pool
+          image: abtt-windows-2025
+          os: windows
+        templateContext:
+          type: releaseJob
+          isProduction: true
+          inputs:
+          - input: pipelineArtifact
+            artifactName: npm-packages
+            targetPath: $(Pipeline.Workspace)/npm-packages
+        steps:
+        - task: EsrpRelease@12
+          displayName: Publish package to npm via ESRP
+          inputs:
+            connectedservicename: '$(EsrpServiceConnection)'
+            usemanagedidentity: true
+            keyvaultname: '$(EsrpKeyVault)'
+            signcertname: '$(EsrpSignCert)'
+            clientid: '$(EsrpClientId)'
+            intent: 'PackageDistribution'
+            contenttype: 'npm'
+            contentsource: 'Folder'
+            folderlocation: '$(Pipeline.Workspace)/npm-packages/packages'
+            waitforreleasecompletion: true
+            owners: '$(EsrpOwners)'
+            approvers: '$(EsrpApprovers)'
+            serviceendpointurl: '$(EsrpServiceEndpointUrl)'
+            mainpublisher: '$(EsrpMainPublisher)'
+            domaintenantid: '$(EsrpDomainTenantId)'
+
+      - job: github_release
+        displayName: Create GitHub release
+        dependsOn: esrp
+        pool:
+          name: 1ES-ABTT-Shared-Pool
+          image: abtt-ubuntu-2404
+          os: linux
+        steps:
+        - checkout: self
+          fetchDepth: 0
+        - task: NodeTool@0
+          displayName: Install Node.js $(nodeVersion)
+          inputs:
+            versionSpec: $(nodeVersion)
+        - task: NpmAuthenticate@0
+          displayName: Authenticate npm feed
+          inputs:
+            workingFile: .npmrc
+        - script: npm install
+          displayName: npm install
+        - bash: |
+            case "$BUILD_SOURCEBRANCH" in
+              refs/heads/*)
+                release_branch="${BUILD_SOURCEBRANCH#refs/heads/}"
+                ;;
+              *)
+                echo "ERROR: Releases must run from a branch, not $BUILD_SOURCEBRANCH"
+                exit 1
+                ;;
+            esac
+            echo "##vso[task.setvariable variable=releaseBranch]$release_branch"
+          displayName: Resolve release branch
+        - script: node ./ci/create-release-notes.js
+          displayName: Create GitHub release
+          env:
+            GH_TOKEN: $(gh-automation.token)
+            branch: $(releaseBranch)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,12 +4,6 @@
 trigger:
 - master
 - releases/*
-variables:
-- name: isMaster
-  value: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
-- name: isRelease
-  value: $[startsWith(variables['Build.SourceBranch'], 'refs/heads/releases')]
-- group: npm-tokens
 parameters:
 - name: nodeVersionList
   type: object
@@ -41,8 +35,8 @@ extends:
     - stage: Build
       displayName: Build typed-rest-client
       jobs:
-      - job: Build_and_Publish
-        displayName: Build and Publish artifact
+      - job: Build_package
+        displayName: Build artifact
         pool:
           name: 1ES-ABTT-Shared-Pool
           image: abtt-ubuntu-2404
@@ -94,37 +88,3 @@ extends:
               displayName: npm run units
             - script: npm run test
               displayName: npm run test
-    - stage: Publish
-      condition: and(succeeded(), eq(variables.isMaster, true), in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual'))
-      jobs:
-      - job: Publish_package
-        displayName: Publish npm package
-        pool:
-          name: 1ES-ABTT-Shared-Pool
-          image: abtt-ubuntu-2404
-          os: linux
-        steps:
-        - task: DownloadPipelineArtifact@2
-          displayName: Download built typed-rest-client package
-          inputs:
-            artifact: _build
-            path: $(Build.SourcesDirectory)/_build
-        - bash: |
-            echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
-            npm publish --registry https://registry.npmjs.org/ --cache $(Agent.TempDirectory)/.npm-cache
-          displayName: Publish typed-rest-client to npm
-          workingDirectory: '_build'
-          env:
-            NPM_TOKEN: $(npm-automation.token)
-          continueOnError: true
-        - script: npm install
-          displayName: npm install
-          continueOnError: true
-          condition: and(succeeded(), eq(variables.isMaster, true))
-        - script: node ./ci/create-release-notes.js
-          continueOnError: true
-          condition: and(succeeded(), eq(variables.isMaster, true))
-          env:
-            GH_TOKEN: $(gh-automation.token)
-            branch: $(Build.SourceBranchName)
-          displayName: Create Release

--- a/ci/create-release-notes.js
+++ b/ci/create-release-notes.js
@@ -179,4 +179,4 @@ async function main(branch) {
     }
 }
 
-main('master');
+main(branch);

--- a/test/tests/httptests.ts
+++ b/test/tests/httptests.ts
@@ -9,6 +9,17 @@ import * as path from 'path';
 
 let sampleFilePath: string = path.join(__dirname, 'testoutput.txt');
 
+function getFirstValue(value: any): any {
+    return Array.isArray(value) ? value[0] : value;
+}
+
+function getResponseData(data: string): string {
+    const prefix = 'data:application/octet-stream;base64,';
+    return data.indexOf(prefix) === 0
+        ? Buffer.from(data.substring(prefix.length), 'base64').toString()
+        : data;
+}
+
 describe('Http Tests', function () {
     let _http: httpm.HttpClient;
     let _httpbin: httpm.HttpClient;
@@ -32,90 +43,82 @@ describe('Http Tests', function () {
     //     "args": {}, 
     //     "headers": {
     //       "Connection": "close", 
-    //       "Host": "httpbin.org", 
+    //       "Host": "httpbingo.org",
     //       "User-Agent": "typed-test-client-tests"
     //     }, 
     //     "origin": "173.95.152.44", 
-    //     "url": "https://httpbin.org/get"
+    //     "url": "https://httpbingo.org/get"
     //  }
     it('does basic http get request', async() => {
-        let res: httpm.HttpClientResponse = await _http.get('http://httpbin.org/get');
+        let res: httpm.HttpClientResponse = await _http.get('http://httpbingo.org/get');
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody();      
         let obj: any = JSON.parse(body);
-        assert(obj.url === "http://httpbin.org/get");
+        assert(obj.url === "http://httpbingo.org/get");
         assert('User-Agent' in obj.headers === true, "User-Agent should be set");
     });
 
     it('does basic http get request with undefined agent', async() => {
         let http: httpm.HttpClient = new httpm.HttpClient(undefined);
-        let res: httpm.HttpClientResponse = await http.get('http://httpbin.org/get');
-        assert(res.message.statusCode == 200, "status code should be 200");
-        let body: string = await res.readBody();      
-        let obj: any = JSON.parse(body);
-        assert(obj.url === "http://httpbin.org/get");
-        assert('User-Agent' in obj.headers === false, "User-Agent should not be set");
+        let res: httpm.HttpClientResponse = await http.get('http://httpbingo.org/get');
+        assert(res.message.statusCode == 402, "httpbingo should reject a missing User-Agent");
     });
 
     it('does basic http get request with null agent', async() => {
         let http: httpm.HttpClient = new httpm.HttpClient(null);
-        let res: httpm.HttpClientResponse = await http.get('http://httpbin.org/get');
-        assert(res.message.statusCode == 200, "status code should be 200");
-        let body: string = await res.readBody();      
-        let obj: any = JSON.parse(body);
-        assert(obj.url === "http://httpbin.org/get");
-        assert('User-Agent' in obj.headers === false, "User-Agent should not be set");
+        let res: httpm.HttpClientResponse = await http.get('http://httpbingo.org/get');
+        assert(res.message.statusCode == 402, "httpbingo should reject a missing User-Agent");
     });
 
     it('does basic http get request with empty agent', async() => {
         let http: httpm.HttpClient = new httpm.HttpClient('');
-        let res: httpm.HttpClientResponse = await http.get('http://httpbin.org/get');
-        assert(res.message.statusCode == 200, "status code should be 200");
-        let body: string = await res.readBody();      
-        let obj: any = JSON.parse(body);
-        assert(obj.url === "http://httpbin.org/get");
-        // Newer Node runtimes can omit headers that are explicitly set to empty strings.
-        let userAgent: string | undefined = obj.headers['User-Agent'];
-        assert(userAgent === '' || userAgent === undefined, "User-Agent should be empty or omitted");
+        let res: httpm.HttpClientResponse = await http.get('http://httpbingo.org/get');
+        assert(res.message.statusCode == 200 || res.message.statusCode == 402, "status code should reflect whether Node sends the empty User-Agent");
+        if (res.message.statusCode == 200) {
+            let body: string = await res.readBody();
+            let obj: any = JSON.parse(body);
+            let userAgent: string | undefined = getFirstValue(obj.headers['User-Agent']);
+            assert(userAgent === '' || userAgent === undefined, "User-Agent should be empty or omitted");
+        }
     });
 
     it('does basic https get request', async() => {
-        let res: httpm.HttpClientResponse = await _http.get('https://httpbin.org/get');
+        let res: httpm.HttpClientResponse = await _http.get('https://httpbingo.org/get');
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody();
         let obj: any = JSON.parse(body);
-        assert(obj.url === "https://httpbin.org/get");
+        assert(obj.url === "https://httpbingo.org/get");
     });
 
     it('does basic http get request with gzip encoded response', async() => {
-        const httpResponse: httpm.HttpClientResponse = await _http.get('http://httpbin.org/gzip');
+        const httpResponse: httpm.HttpClientResponse = await _http.get('http://httpbingo.org/gzip');
         const body: string = await httpResponse.readBody();
         const bodyAsJSON:any = JSON.parse(body);
 
-        assert(bodyAsJSON.headers && bodyAsJSON.headers.Host === "httpbin.org");
+        assert(bodyAsJSON.headers && getFirstValue(bodyAsJSON.headers.Host) === "httpbingo.org");
         assert(httpResponse.message.statusCode == 200, "status code should be 200");
     });
 
     it('does basic https get request with gzip encoded response', async() => {
-        const httpResponse: httpm.HttpClientResponse = await _http.get('https://httpbin.org/gzip');
+        const httpResponse: httpm.HttpClientResponse = await _http.get('https://httpbingo.org/gzip');
         const body: string = await httpResponse.readBody();
         const bodyAsJSON:any = JSON.parse(body);
 
-        assert(bodyAsJSON.headers && bodyAsJSON.headers.Host === "httpbin.org");
+        assert(bodyAsJSON.headers && getFirstValue(bodyAsJSON.headers.Host) === "httpbingo.org");
         assert(httpResponse.message.statusCode == 200, "status code should be 200");
     });
 
     it('does basic http get request with basic auth', async() => {
         let bh: hm.BasicCredentialHandler = new hm.BasicCredentialHandler('johndoe', 'password');
         let http: httpm.HttpClient = new httpm.HttpClient('typed-rest-client-tests', [bh]);
-        let res: httpm.HttpClientResponse = await http.get('http://httpbin.org/get');
+        let res: httpm.HttpClientResponse = await http.get('http://httpbingo.org/get');
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody(); 
         let obj:any = JSON.parse(body);
-        let auth: string = obj.headers.Authorization;
+        let auth: string = getFirstValue(obj.headers.Authorization);
         let creds: string = Buffer.from(auth.substring('Basic '.length), 'base64').toString();
         assert(creds === 'johndoe:password', "should be the username and password");
-        assert(obj.url === "http://httpbin.org/get");
+        assert(obj.url === "http://httpbingo.org/get");
     });
     
     it('does basic http get request with pat token auth', async() => {
@@ -123,14 +126,14 @@ describe('Http Tests', function () {
         let ph: hm.PersonalAccessTokenCredentialHandler = 
             new hm.PersonalAccessTokenCredentialHandler(token);
         let http: httpm.HttpClient = new httpm.HttpClient('typed-rest-client-tests', [ph]);
-        let res: httpm.HttpClientResponse = await http.get('http://httpbin.org/get');
+        let res: httpm.HttpClientResponse = await http.get('http://httpbingo.org/get');
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody(); 
         let obj:any = JSON.parse(body);
-        let auth: string = obj.headers.Authorization;
+        let auth: string = getFirstValue(obj.headers.Authorization);
         let creds: string = Buffer.from(auth.substring('Basic '.length), 'base64').toString();
         assert(creds === 'PAT:' + token, "creds should be the token");
-        assert(obj.url === "http://httpbin.org/get");
+        assert(obj.url === "http://httpbingo.org/get");
     });
     
     it('does basic http get request with default headers', async() => {
@@ -140,13 +143,13 @@ describe('Http Tests', function () {
                 'Content-Type': 'application/json'
             }
         });
-        let res: httpm.HttpClientResponse = await http.get('http://httpbin.org/get');
+        let res: httpm.HttpClientResponse = await http.get('http://httpbingo.org/get');
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody(); 
         let obj:any = JSON.parse(body);
-        assert(obj.headers.Accept === 'application/json', "Accept header should be 'application/json'");
-        assert(obj.headers['Content-Type'] === 'application/json', "Content-Type header should be 'application/json'");
-        assert(obj.url === "http://httpbin.org/get");
+        assert(getFirstValue(obj.headers.Accept) === 'application/json', "Accept header should be 'application/json'");
+        assert(getFirstValue(obj.headers['Content-Type']) === 'application/json', "Content-Type header should be 'application/json'");
+        assert(obj.url === "http://httpbingo.org/get");
     });
     
     it('does basic http get request with merged headers', async() => {
@@ -156,65 +159,65 @@ describe('Http Tests', function () {
                 'Content-Type': 'application/json'
             }
         });
-        let res: httpm.HttpClientResponse = await http.get('http://httpbin.org/get', {
+        let res: httpm.HttpClientResponse = await http.get('http://httpbingo.org/get', {
             'content-type': 'application/x-www-form-urlencoded'
         });
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody(); 
         let obj:any = JSON.parse(body);
-        assert(obj.headers.Accept === 'application/json', "Accept header should be 'application/json'");
-        assert(obj.headers['Content-Type'] === 'application/x-www-form-urlencoded', "Content-Type header should be 'application/x-www-form-urlencoded'");
-        assert(obj.url === "http://httpbin.org/get");
+        assert(getFirstValue(obj.headers.Accept) === 'application/json', "Accept header should be 'application/json'");
+        assert(getFirstValue(obj.headers['Content-Type']) === 'application/x-www-form-urlencoded', "Content-Type header should be 'application/x-www-form-urlencoded'");
+        assert(obj.url === "http://httpbingo.org/get");
     });
 
     it('pipes a get request', () => {
         return new Promise<void>(async (resolve, reject) => {
             let file: NodeJS.WritableStream = fs.createWriteStream(sampleFilePath);
-            (await _http.get('https://httpbin.org/get')).message.pipe(file).on('close', () => {
+            (await _http.get('https://httpbingo.org/get')).message.pipe(file).on('close', () => {
                 let body: string = fs.readFileSync(sampleFilePath).toString();
                 let obj:any = JSON.parse(body);
-                assert(obj.url === "https://httpbin.org/get", "response from piped stream should have url");
+                assert(obj.url === "https://httpbingo.org/get", "response from piped stream should have url");
                 resolve();
             });
         });
     });
     
     it('does basic get request with redirects', async() => {
-        let res: httpm.HttpClientResponse = await _http.get(`https://httpbin.org/redirect-to?url=` + encodeURIComponent("https://httpbin.org/anything"))
+        let res: httpm.HttpClientResponse = await _http.get(`https://httpbingo.org/redirect-to?url=` + encodeURIComponent("https://httpbingo.org/anything"))
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody();
         let obj:any = JSON.parse(body);
-        assert(obj.url === "https://httpbin.org/anything");
+        assert(obj.url === "https://httpbingo.org/anything");
     });
 
     it('does basic get request with redirects (303)', async() => {
-        let res: httpm.HttpClientResponse = await _http.get(`https://httpbin.org/redirect-to?url=` + encodeURIComponent("https://httpbin.org/anything") + '&status_code=303')
+        let res: httpm.HttpClientResponse = await _http.get(`https://httpbingo.org/redirect-to?url=` + encodeURIComponent("https://httpbingo.org/anything") + '&status_code=303')
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody();
         let obj:any = JSON.parse(body);
-        assert(obj.url === "https://httpbin.org/anything");
+        assert(obj.url === "https://httpbingo.org/anything");
     });
 
     it('returns 404 for not found get request on redirect', async() => {
-        let res: httpm.HttpClientResponse = await _http.get(`https://httpbin.org/redirect-to?url=` + encodeURIComponent("https://httpbin.org/status/404") + '&status_code=303')
+        let res: httpm.HttpClientResponse = await _http.get(`https://httpbingo.org/redirect-to?url=` + encodeURIComponent("https://httpbingo.org/status/404") + '&status_code=303')
         assert(res.message.statusCode == 404, "status code should be 404");
         let body: string = await res.readBody();
     });
 
     it('does not follow redirects if disabled', async() => {
         let http: httpm.HttpClient = new httpm.HttpClient('typed-test-client-tests', null, { allowRedirects: false });
-        let res: httpm.HttpClientResponse = await http.get(`https://httpbin.org/redirect-to?url=` + encodeURIComponent("https://httpbin.org/anything"))
+        let res: httpm.HttpClientResponse = await http.get(`https://httpbingo.org/redirect-to?url=` + encodeURIComponent("https://httpbingo.org/anything"))
         assert(res.message.statusCode == 302, "status code should be 302");
         let body: string = await res.readBody();
     });
 
     it('does basic head request', async() => {
-        let res: httpm.HttpClientResponse = await _http.head('http://httpbin.org/get');
+        let res: httpm.HttpClientResponse = await _http.head('http://httpbingo.org/get');
         assert(res.message.statusCode == 200, "status code should be 200");
     });
 
     it('does basic http delete request', async() => {
-        let res: httpm.HttpClientResponse = await _http.del('http://httpbin.org/delete');
+        let res: httpm.HttpClientResponse = await _http.del('http://httpbingo.org/delete');
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody();      
         let obj:any = JSON.parse(body);
@@ -222,32 +225,32 @@ describe('Http Tests', function () {
 
     it('does basic http post request', async() => {
         let b: string = 'Hello World!';
-        let res: httpm.HttpClientResponse = await _http.post('http://httpbin.org/post', b);
+        let res: httpm.HttpClientResponse = await _http.post('http://httpbingo.org/post', b);
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody();
         let obj:any = JSON.parse(body);
-        assert(obj.data === b);
-        assert(obj.url === "http://httpbin.org/post");
+        assert(getResponseData(obj.data) === b);
+        assert(obj.url === "http://httpbingo.org/post");
     });
     
     it('does basic http patch request', async() => {
         let b: string = 'Hello World!';
-        let res: httpm.HttpClientResponse = await _http.patch('http://httpbin.org/patch', b);
+        let res: httpm.HttpClientResponse = await _http.patch('http://httpbingo.org/patch', b);
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody();
         let obj:any = JSON.parse(body);
-        assert(obj.data === b);
-        assert(obj.url === "http://httpbin.org/patch");
+        assert(getResponseData(obj.data) === b);
+        assert(obj.url === "http://httpbingo.org/patch");
     });
     
     it('does basic http options request', async() => {
-        let res: httpm.HttpClientResponse = await _http.options('http://httpbin.org');
+        let res: httpm.HttpClientResponse = await _http.options('http://httpbingo.org');
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody();
     });
     
     it('returns 404 for not found get request', async() => {
-        let res: httpm.HttpClientResponse = await _http.get('http://httpbin.org/status/404');
+        let res: httpm.HttpClientResponse = await _http.get('http://httpbingo.org/status/404');
         assert(res.message.statusCode == 404, "status code should be 404");
         let body: string = await res.readBody();
     });
@@ -264,20 +267,20 @@ describe('Http Tests with keepAlive', function () {
     });
 
     it('does basic http get request with keepAlive true', async() => {
-        let res: httpm.HttpClientResponse = await _http.get('http://httpbin.org/get');
+        let res: httpm.HttpClientResponse = await _http.get('http://httpbingo.org/get');
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody();      
         let obj:any = JSON.parse(body);
-        assert(obj.url === "http://httpbin.org/get");
+        assert(obj.url === "http://httpbingo.org/get");
     });
 
     it('does basic head request with keepAlive true', async() => {
-        let res: httpm.HttpClientResponse = await _http.head('http://httpbin.org/get');
+        let res: httpm.HttpClientResponse = await _http.head('http://httpbingo.org/get');
         assert(res.message.statusCode == 200, "status code should be 200");
     });    
 
     it('does basic http delete request with keepAlive true', async() => {
-        let res: httpm.HttpClientResponse = await _http.del('http://httpbin.org/delete');
+        let res: httpm.HttpClientResponse = await _http.del('http://httpbingo.org/delete');
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody();      
         let obj:any = JSON.parse(body);
@@ -285,26 +288,26 @@ describe('Http Tests with keepAlive', function () {
 
     it('does basic http post request with keepAlive true', async() => {
         let b: string = 'Hello World!';
-        let res: httpm.HttpClientResponse = await _http.post('http://httpbin.org/post', b);
+        let res: httpm.HttpClientResponse = await _http.post('http://httpbingo.org/post', b);
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody();
         let obj:any = JSON.parse(body);
-        assert(obj.data === b);
-        assert(obj.url === "http://httpbin.org/post");
+        assert(getResponseData(obj.data) === b);
+        assert(obj.url === "http://httpbingo.org/post");
     });
     
     it('does basic http patch request with keepAlive true', async() => {
         let b: string = 'Hello World!';
-        let res: httpm.HttpClientResponse = await _http.patch('http://httpbin.org/patch', b);
+        let res: httpm.HttpClientResponse = await _http.patch('http://httpbingo.org/patch', b);
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody();
         let obj:any = JSON.parse(body);
-        assert(obj.data === b);
-        assert(obj.url === "http://httpbin.org/patch");
+        assert(getResponseData(obj.data) === b);
+        assert(obj.url === "http://httpbingo.org/patch");
     }); 
     
     it('does basic http options request with keepAlive true', async() => {
-        let res: httpm.HttpClientResponse = await _http.options('http://httpbin.org');
+        let res: httpm.HttpClientResponse = await _http.options('http://httpbingo.org');
         assert(res.message.statusCode == 200, "status code should be 200");
         let body: string = await res.readBody();
     });

--- a/test/tests/resttests.ts
+++ b/test/tests/resttests.ts
@@ -14,6 +14,10 @@ export interface HttpBinData {
     args?: any
 }
 
+function getFirstValue(value: any): any {
+    return Array.isArray(value) ? value[0] : value;
+}
+
 describe('Rest Tests', function () {
     let _rest: restm.RestClient;
     let _restBin: restm.RestClient;
@@ -21,7 +25,7 @@ describe('Rest Tests', function () {
 
     before(() => {
         _rest = new restm.RestClient('typed-rest-client-tests');
-        _restBin = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org');
+        _restBin = new restm.RestClient('typed-rest-client-tests', 'https://httpbingo.org');
         _options = {
             queryParameters: {
                 params: {
@@ -45,26 +49,26 @@ describe('Rest Tests', function () {
     it('gets a resource', async() => {
         this.timeout(3000);
 
-        let restRes: restm.IRestResponse<HttpBinData> = await _rest.get<HttpBinData>('https://httpbin.org/get');
+        let restRes: restm.IRestResponse<HttpBinData> = await _rest.get<HttpBinData>('https://httpbingo.org/get');
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/get');
+        assert(restRes.result && restRes.result.url === 'https://httpbingo.org/get');
     });
 
     it('gets a resource with baseUrl', async() => {
         let restRes: restm.IRestResponse<HttpBinData> = await _restBin.get<HttpBinData>('get');
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/get');
+        assert(restRes.result && restRes.result.url === 'https://httpbingo.org/get');
     });
 
     it('gets a resource passing Query Parameters', async() => {
         this.timeout(3000);
-        const response: restm.IRestResponse<HttpBinData> = await _rest.get<HttpBinData>('https://httpbin.org/get', _options);
+        const response: restm.IRestResponse<HttpBinData> = await _rest.get<HttpBinData>('https://httpbingo.org/get', _options);
 
         assert(response.statusCode == 200, "statusCode should be 200");
-        assert(response.result.url === 'https://httpbin.org/get?id=1&type=compact');
+        assert(response.result.url === 'https://httpbingo.org/get?id=1&type=compact');
 
         Object.keys(_options.queryParameters.params).forEach(key => {
-            const actual = response.result.args[key];
+            const actual = getFirstValue(response.result.args[key]);
             const expected = _options.queryParameters.params[key];
 
             assert(expected == actual);
@@ -75,10 +79,10 @@ describe('Rest Tests', function () {
         const response: restm.IRestResponse<HttpBinData> = await _restBin.get<HttpBinData>('get', _options);
 
         assert(response.statusCode == 200, "statusCode should be 200");
-        assert(response.result.url === 'https://httpbin.org/get?id=1&type=compact');
+        assert(response.result.url === 'https://httpbingo.org/get?id=1&type=compact');
 
         Object.keys(_options.queryParameters.params).forEach(key => {
-            const actual = response.result.args[key];
+            const actual = getFirstValue(response.result.args[key]);
             const expected = _options.queryParameters.params[key];
 
             assert(expected == actual);
@@ -87,9 +91,9 @@ describe('Rest Tests', function () {
 
     it('creates a resource', async() => {
         let res: any = { name: 'foo' };
-        let restRes: restm.IRestResponse<HttpBinData> = await _rest.create<HttpBinData>('https://httpbin.org/post', res);
+        let restRes: restm.IRestResponse<HttpBinData> = await _rest.create<HttpBinData>('https://httpbingo.org/post', res);
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/post');
+        assert(restRes.result && restRes.result.url === 'https://httpbingo.org/post');
         assert(restRes.result && restRes.result.json.name === 'foo');
     });
 
@@ -97,7 +101,7 @@ describe('Rest Tests', function () {
         let res: any = { name: 'foo' };
         let restRes: restm.IRestResponse<HttpBinData> = await _restBin.create<HttpBinData>('post', res);
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/post');
+        assert(restRes.result && restRes.result.url === 'https://httpbingo.org/post');
         assert(restRes.result && restRes.result.json.name === 'foo');
     });
 
@@ -105,9 +109,9 @@ describe('Rest Tests', function () {
         this.timeout(3000);
 
         let res: any = { name: 'foo' };
-        let restRes: restm.IRestResponse<HttpBinData> = await _rest.replace<HttpBinData>('https://httpbin.org/put', res);
+        let restRes: restm.IRestResponse<HttpBinData> = await _rest.replace<HttpBinData>('https://httpbingo.org/put', res);
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/put');
+        assert(restRes.result && restRes.result.url === 'https://httpbingo.org/put');
         assert(restRes.result && restRes.result.json.name === 'foo');
     });
 
@@ -115,15 +119,15 @@ describe('Rest Tests', function () {
         let res: any = { name: 'foo' };
         let restRes: restm.IRestResponse<HttpBinData> = await _restBin.replace<HttpBinData>('put', res);
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/put');
+        assert(restRes.result && restRes.result.url === 'https://httpbingo.org/put');
         assert(restRes.result && restRes.result.json.name === 'foo');
     });
 
     it('updates a resource', async() => {
         let res: any = { name: 'foo' };
-        let restRes: restm.IRestResponse<HttpBinData> = await _rest.update<HttpBinData>('https://httpbin.org/patch', res);
+        let restRes: restm.IRestResponse<HttpBinData> = await _rest.update<HttpBinData>('https://httpbingo.org/patch', res);
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/patch');
+        assert(restRes.result && restRes.result.url === 'https://httpbingo.org/patch');
         assert(restRes.result && restRes.result.json.name === 'foo');
     });
 
@@ -131,31 +135,31 @@ describe('Rest Tests', function () {
         let res: any = { name: 'foo' };
         let restRes: restm.IRestResponse<HttpBinData> = await _restBin.update<HttpBinData>('patch', res);
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/patch');
+        assert(restRes.result && restRes.result.url === 'https://httpbingo.org/patch');
         assert(restRes.result && restRes.result.json.name === 'foo');
     });
 
     it('deletes a resource', async() => {
-        let restRes: restm.IRestResponse<HttpBinData> = await _rest.del<HttpBinData>('https://httpbin.org/delete');
+        let restRes: restm.IRestResponse<HttpBinData> = await _rest.del<HttpBinData>('https://httpbingo.org/delete');
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/delete');
+        assert(restRes.result && restRes.result.url === 'https://httpbingo.org/delete');
     });
 
     it('deletes a resource with a baseUrl', async() => {
         let restRes: restm.IRestResponse<HttpBinData> = await _restBin.del<HttpBinData>('delete');
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/delete');
+        assert(restRes.result && restRes.result.url === 'https://httpbingo.org/delete');
     });
 
     it('deletes a resource passing Query Parameters', async () => {
         this.timeout(3000);
-        const response: restm.IRestResponse<HttpBinData> = await _rest.del<HttpBinData>('https://httpbin.org/delete', _options);
+        const response: restm.IRestResponse<HttpBinData> = await _rest.del<HttpBinData>('https://httpbingo.org/delete', _options);
 
         assert(response.statusCode == 200, "statusCode should be 200");
-        assert(response.result.url === 'https://httpbin.org/delete?id=1&type=compact');
+        assert(response.result.url === 'https://httpbingo.org/delete?id=1&type=compact');
 
         Object.keys(_options.queryParameters.params).forEach(key => {
-            const actual = response.result.args[key];
+            const actual = getFirstValue(response.result.args[key]);
             const expected = _options.queryParameters.params[key];
 
             assert(expected == actual);
@@ -166,10 +170,10 @@ describe('Rest Tests', function () {
         const response: restm.IRestResponse<HttpBinData> = await _restBin.del<HttpBinData>('delete', _options);
 
         assert(response.statusCode == 200, "statusCode should be 200");
-        assert(response.result.url === 'https://httpbin.org/delete?id=1&type=compact');
+        assert(response.result.url === 'https://httpbingo.org/delete?id=1&type=compact');
 
         Object.keys(_options.queryParameters.params).forEach(key => {
-            const actual = response.result.args[key];
+            const actual = getFirstValue(response.result.args[key]);
             const expected = _options.queryParameters.params[key];
 
             assert(expected == actual);
@@ -177,7 +181,7 @@ describe('Rest Tests', function () {
     });
 
     it('does an options request', async() => {
-        let restRes: restm.IRestResponse<HttpBinData> = await _rest.options<HttpBinData>('https://httpbin.org');
+        let restRes: restm.IRestResponse<HttpBinData> = await _rest.options<HttpBinData>('https://httpbingo.org');
         assert(restRes.statusCode == 200, "statusCode should be 200");
     });
 
@@ -198,7 +202,7 @@ describe('Rest Tests', function () {
         this.timeout(3000);
 
         try {
-            let restRes: restm.IRestResponse<HttpBinData> = await _rest.get<HttpBinData>('https://httpbin.org/status/404');
+            let restRes: restm.IRestResponse<HttpBinData> = await _rest.get<HttpBinData>('https://httpbingo.org/status/404');
 
             assert(restRes.statusCode == 404, "statusCode should be 404");
             assert(restRes.result === null, "object should be null");
@@ -215,7 +219,7 @@ describe('Rest Tests', function () {
     //
     it('gets and handles unauthorized (401)', async() => {
         try {
-            let restRes: restm.IRestResponse<HttpBinData> = await _rest.get<HttpBinData>('https://httpbin.org/status/401');
+            let restRes: restm.IRestResponse<HttpBinData> = await _rest.get<HttpBinData>('https://httpbingo.org/status/401');
             assert(false, "should throw");
         }
         catch(err) {
@@ -232,7 +236,7 @@ describe('Rest Tests', function () {
     //
     it('gets and handles a server error (500)', async() => {
         try {
-            let restRes: restm.IRestResponse<HttpBinData> = await _rest.get<HttpBinData>('https://httpbin.org/status/500');
+            let restRes: restm.IRestResponse<HttpBinData> = await _rest.get<HttpBinData>('https://httpbingo.org/status/500');
             assert(false, "should throw");
         }
         catch(err) {
@@ -266,93 +270,93 @@ describe('Rest Tests', function () {
         this.timeout(3000);
 
         // Arrange
-        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything');
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbingo.org/anything');
 
         // Act
         let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra');
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/anything/anythingextra');
+        assert(restRes.result && restRes.result.url === 'https://httpbingo.org/anything/anythingextra');
     });
 
     it('maintains the path from the base url with no slashes', async() => {
         // Arrange
-        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything');
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbingo.org/anything');
 
         // Act
         let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra');
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/anything/anythingextra');
+        assert(restRes.result && restRes.result.url === 'https://httpbingo.org/anything/anythingextra');
     });
 
     it('maintains the path from the base url with double slashes', async() => {
         // Arrange
-        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything/');
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbingo.org/anything/');
 
         // Act
         let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra');
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/anything/anythingextra');
+        assert(restRes.result && restRes.result.url === 'https://httpbingo.org/anything/anythingextra');
     });
 
     it('maintains the path from the base url with multiple parts', async() => {
         // Arrange
-        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything/extrapart');
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbingo.org/anything/extrapart');
 
         // Act
         let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra');
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/anything/extrapart/anythingextra');
+        assert(restRes.result && restRes.result.url === 'https://httpbingo.org/anything/extrapart/anythingextra');
     });
 
     it('maintains the path from the base url where request has multiple parts', async() => {
         // Arrange
-        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything');
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbingo.org/anything');
 
         // Act
         let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra/moreparts');
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/anything/anythingextra/moreparts');
+        assert(restRes.result && restRes.result.url === 'https://httpbingo.org/anything/anythingextra/moreparts');
     });
 
     it('maintains the path from the base url where both have multiple parts', async() => {
         // Arrange
-        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything/multiple');
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbingo.org/anything/multiple');
 
         // Act
         let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra/moreparts');
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/anything/multiple/anythingextra/moreparts');
+        assert(restRes.result && restRes.result.url === 'https://httpbingo.org/anything/multiple/anythingextra/moreparts');
     });
 
     it('maintains the path from the base url where request has query parameters', async() => {
         // Arrange
         this.timeout(3000);
-        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org/anything/multiple');
+        let rest = new restm.RestClient('typed-rest-client-tests', 'https://httpbingo.org/anything/multiple');
 
         // Act
         let restRes: restm.IRestResponse<HttpBinData> = await rest.get<HttpBinData>('anythingextra/moreparts?foo=bar&baz=top');
 
         // Assert
         assert(restRes.statusCode == 200, "statusCode should be 200");
-        assert(restRes.result && restRes.result.url === 'https://httpbin.org/anything/multiple/anythingextra/moreparts?foo=bar&baz=top');
-        assert(restRes.result && restRes.result.args.foo === 'bar');
-        assert(restRes.result && restRes.result.args.baz === 'top');
+        assert(restRes.result && restRes.result.url === 'https://httpbingo.org/anything/multiple/anythingextra/moreparts?foo=bar&baz=top');
+        assert(restRes.result && getFirstValue(restRes.result.args.foo) === 'bar');
+        assert(restRes.result && getFirstValue(restRes.result.args.baz) === 'top');
     });
 
     it('preserves trailing slashes in URLs', async () => {
-        const res = util.getUrl('get/foo/', 'http://httpbin.org/bar');
-        assert.equal(res, 'http://httpbin.org/bar/get/foo/');
+        const res = util.getUrl('get/foo/', 'http://httpbingo.org/bar');
+        assert.equal(res, 'http://httpbingo.org/bar/get/foo/');
     });
 });

--- a/test/units/resttests.ts
+++ b/test/units/resttests.ts
@@ -16,13 +16,11 @@ export interface HttpData {
 
 describe('Rest Tests', function () {
     let _rest: restm.RestClient;
-    let _restBin: restm.RestClient;
     let _restMic: restm.RestClient;
     let _queryParams: ifm.IRequestQueryParams;
 
     before(() => {
         _rest = new restm.RestClient('typed-rest-client-tests');
-        _restBin = new restm.RestClient('typed-rest-client-tests', 'https://httpbin.org');
         _restMic = new restm.RestClient('typed-rest-client-tests', 'http://microsoft.com');
         _queryParams = {
             params: {


### PR DESCRIPTION
## Summary
- add a manual two-stage ESRP release pipeline that builds, tests, and packs `typed-rest-client` into the `npm-packages/packages` artifact contract
- publish through `EsrpRelease@12`, then create the GitHub release in a separate dependent job
- remove direct npm publishing, release credentials, and GitHub release creation from the main CI pipeline
- preserve full release branch names when generating GitHub release notes
- add a safe dry-run mode for validating the complete build and package flow without releasing
- migrate external integration tests from httpbin.org to httpbingo.org

## Dry run
When manually queueing the release pipeline, set the boolean `dryRun` parameter to `true` to run the full `BuildAndPack` stage: install, build, test, `npm pack`, the zero-tarball guard, and the `_manifest/` guard. The ESRP publish stage and its dependent GitHub-release job are omitted at compile time, so no npm package, GitHub tag, or GitHub release is created.

`dryRun` defaults to `false`; use the default only for an intended production release.

## Validation
- parsed both Azure Pipelines YAML files and validated the dry-run stage structure
- `npm install` and `npm run build` succeeded
- `npm run units` succeeded
- `npm pack` produced `typed-rest-client-3.0.0.tgz`; archive guard confirmed no `_manifest/`
- confirmed no direct `npm publish` or npm automation token references remain
- `npm test` passed with 108 unit and 57 integration tests using httpbingo.org

## Manual prerequisites
Requires the ESRP Release extension, approved publisher identity, Key Vault signing certificate and role, WIF service connection, npm allow-list/publish rights, and the existing `esrp-npm-release` and `github-release` variable groups before registering/running the new release pipeline.

---
Related work item: [AB#2440593](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2440593)