### PR TITLE
Remove invalid GitHub release variable group

### DIFF
--- a/.azure-pipelines/azure-pipelines-release.yml
+++ b/.azure-pipelines/azure-pipelines-release.yml
@@ -11,7 +11,6 @@ parameters:
 
 variables:
 - group: esrp-npm-release
-- group: github-release
 - name: nodeVersion
   value: '20.x'
 
@@ -120,41 +119,3 @@ extends:
               serviceendpointurl: '$(EsrpServiceEndpointUrl)'
               mainpublisher: '$(EsrpMainPublisher)'
               domaintenantid: '$(EsrpDomainTenantId)'
-
-        - job: github_release
-          displayName: Create GitHub release
-          dependsOn: esrp
-          pool:
-            name: 1ES-ABTT-Shared-Pool
-            image: abtt-ubuntu-2404
-            os: linux
-          steps:
-          - checkout: self
-            fetchDepth: 0
-          - task: NodeTool@0
-            displayName: Install Node.js $(nodeVersion)
-            inputs:
-              versionSpec: $(nodeVersion)
-          - task: NpmAuthenticate@0
-            displayName: Authenticate npm feed
-            inputs:
-              workingFile: .npmrc
-          - script: npm ci
-            displayName: npm ci
-          - bash: |
-              case "$BUILD_SOURCEBRANCH" in
-                refs/heads/*)
-                  release_branch="${BUILD_SOURCEBRANCH#refs/heads/}"
-                  ;;
-                *)
-                  echo "ERROR: Releases must run from a branch, not $BUILD_SOURCEBRANCH"
-                  exit 1
-                  ;;
-              esac
-              echo "##vso[task.setvariable variable=releaseBranch]$release_branch"
-            displayName: Resolve release branch
-          - script: node ./ci/create-release-notes.js
-            displayName: Create GitHub release
-            env:
-              GH_TOKEN: $(gh-automation.token)
-              branch: $(releaseBranch)


### PR DESCRIPTION
## Summary
- remove the nonexistent `github-release` variable group from the release pipeline
- remove the GitHub release job that depended on the unavailable `gh-automation.token`
- keep the release pipeline focused on npm publication through ESRP

## Azure DevOps
- authorized the existing `esrp-npm-release` variable group for `typed-rest-client.Release` (pipeline 23068)
- addresses the YAML load failure from build 31906441